### PR TITLE
Ensure clean build folder when publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:module": "tsc -p tsconfig.module.json",
     "test": "npm run lint && env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha",
     "lint": "eslint . --ext .ts",
-    "build-publish": "npm run build && npm publish"
+    "build-publish": "rm -rf build && npm run build && npm publish"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Somehow there are still references to `axios` in the new package. 
We think it might be related to some old code in the build folder.