### PR TITLE
Add support for bytes4 and bytes4[] + add tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2777,6 +2777,7 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
       "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+      "deprecated": "This module has been superseded by the multiformats module",
       "dev": true,
       "dependencies": {
         "buffer": "^5.5.0",
@@ -2794,6 +2795,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
       "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+      "deprecated": "This module has been superseded by the multiformats module",
       "dev": true,
       "dependencies": {
         "buffer": "^5.6.0",
@@ -7710,7 +7712,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
       "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
-      "deprecated": "stable api reached",
+      "deprecated": "This module has been superseded by the multiformats module",
       "dev": true,
       "dependencies": {
         "varint": "^5.0.0"

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -70,7 +70,7 @@ const KECCAK256_BYTES = {
 export const HASH_FUNCTIONS: {
   [key: string]: {
     method: Function;
-    name: string;
+    name: SUPPORTED_HASH_FUNCTION_STRINGS;
     sig: SUPPORTED_HASH_FUNCTIONS;
   };
 } = {

--- a/src/lib/encoder.test.ts
+++ b/src/lib/encoder.test.ts
@@ -7,16 +7,12 @@ import {
   encodeValueContent,
   decodeValueContent,
 } from './encoder';
-import { ERC725 } from '../index';
-import { ERC725JSONSchema } from '../types/ERC725JSONSchema';
-import { hashData } from './utils';
 import {
   SUPPORTED_HASH_FUNCTION_HASHES,
   SUPPORTED_HASH_FUNCTION_STRINGS,
 } from './constants';
-import { Schema } from '../../test/generatedSchema';
 
-describe('encoder', () => {
+describe.only('encoder', () => {
   describe('valueType', () => {
     const testCases = [
       {
@@ -274,85 +270,6 @@ describe('encoder', () => {
           (error: any) =>
             error.message ===
             'You have to provide either the hash or the json via the respective properties',
-        );
-      });
-
-      // This test case is outside of the scope of 'encoder.ts' as it uses the global "myERC725" class.
-      // It should go somewhere else.
-      it('should encode/decode JSON properly', () => {
-        const schema: ERC725JSONSchema[] = [
-          {
-            name: 'LSP3Profile',
-            key: '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
-            keyType: 'Singleton',
-            valueContent: 'JSONURL',
-            valueType: 'bytes',
-          },
-        ];
-
-        const myERC725 = new ERC725<Schema>(schema);
-
-        const json = {
-          name: 'rryter',
-          description: 'Web Developer located in Switzerland.',
-          profileImage: [
-            {
-              width: 1350,
-              height: 1800,
-              hashFunction: 'keccak256(bytes)',
-              hash: '0x229b60ea5b58e1ab8e6f1063300be110bb4fa663ba75d3814d60104ac6b74497',
-              url: 'ipfs://Qmbv9j6iCDDYJ1NXHTZnNHDJ6qaaKkZsf79jhUMFAXcfDR',
-            },
-            {
-              width: 768,
-              height: 1024,
-              hashFunction: 'keccak256(bytes)',
-              hash: '0x320db57770084f114988c8a94bcf219ca66c69421590466a45f382cd84995c2b',
-              url: 'ipfs://QmS4m2LmRpay7Jij4DCpvaW5zKZYy43ATZdRxUkUND6nG3',
-            },
-          ],
-          backgroundImage: [
-            {
-              width: 1024,
-              height: 768,
-              hashFunction: 'keccak256(bytes)',
-              hash: '0xbe2d39fe1e0b1911155afc74010db3483528a2b645dea8fcf47bdc34147769be',
-              url: 'ipfs://QmQ6ujfKSc91F44KtMe6WRTSCXoSdCjomQUy8hCUxHMr28',
-            },
-            {
-              width: 640,
-              height: 480,
-              hashFunction: 'keccak256(bytes)',
-              hash: '0xb115f2bf09994e79726db27a7b8d5a0de41a5b81d11b59b3038fa158718266ff',
-              url: 'ipfs://QmakaRZxJMMqwQFJY98J3wjbqYVDnaSZ9sEqBF9iMv3GNX',
-            },
-          ],
-          tags: ['public profile'],
-          links: [],
-        };
-
-        const encodedData = myERC725.encodeData({
-          LSP3Profile: {
-            json,
-            url: 'ifps://QmbKvCVEePiDKxuouyty9bMsWBAxZDGr2jhxd4pLGLx95D',
-          },
-        });
-
-        const decodedData = myERC725.decodeData({
-          LSP3Profile: encodedData.LSP3Profile.value,
-        });
-
-        assert.deepStrictEqual(
-          decodedData.LSP3Profile.url,
-          'ifps://QmbKvCVEePiDKxuouyty9bMsWBAxZDGr2jhxd4pLGLx95D',
-        );
-        assert.deepStrictEqual(
-          decodedData.LSP3Profile.hash,
-          hashData(json, SUPPORTED_HASH_FUNCTION_STRINGS.KECCAK256_UTF8),
-        );
-        assert.deepStrictEqual(
-          decodedData.LSP3Profile.hashFunction,
-          SUPPORTED_HASH_FUNCTION_STRINGS.KECCAK256_UTF8,
         );
       });
     });

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -75,45 +75,55 @@ const decodeDataSourceWithHash = (
 
 const valueTypeEncodingMap = {
   string: {
-    encode: (value) => abiCoder.encodeParameter('string', value),
-    decode: (value) => abiCoder.decodeParameter('string', value),
+    encode: (value: string) => abiCoder.encodeParameter('string', value),
+    decode: (value: string) => abiCoder.decodeParameter('string', value),
   },
   address: {
-    encode: (value) => abiCoder.encodeParameter('address', value),
-    decode: (value) => abiCoder.decodeParameter('address', value),
+    encode: (value: string) => abiCoder.encodeParameter('address', value),
+    decode: (value: string) => abiCoder.decodeParameter('address', value),
   },
   // NOTE: We could add conditional handling of numeric values here...
   uint256: {
-    encode: (value) => abiCoder.encodeParameter('uint256', value),
-    decode: (value) => abiCoder.decodeParameter('uint256', value),
+    encode: (value: string | number) =>
+      abiCoder.encodeParameter('uint256', value),
+    decode: (value: string) => abiCoder.decodeParameter('uint256', value),
   },
   bytes32: {
     encode: (value) => abiCoder.encodeParameter('bytes32', value),
-    decode: (value) => abiCoder.decodeParameter('bytes32', value),
+    decode: (value: string) => abiCoder.decodeParameter('bytes32', value),
+  },
+  bytes4: {
+    encode: (value) => abiCoder.encodeParameter('bytes4', value),
+    decode: (value: string) => abiCoder.decodeParameter('bytes4', value),
   },
   bytes: {
-    encode: (value) => abiCoder.encodeParameter('bytes', value),
-    decode: (value) => abiCoder.decodeParameter('bytes', value),
+    encode: (value: string) => abiCoder.encodeParameter('bytes', value),
+    decode: (value: string) => abiCoder.decodeParameter('bytes', value),
   },
   'string[]': {
-    encode: (value) => abiCoder.encodeParameter('string[]', value),
-    decode: (value) => abiCoder.decodeParameter('string[]', value),
+    encode: (value: string[]) => abiCoder.encodeParameter('string[]', value),
+    decode: (value: string) => abiCoder.decodeParameter('string[]', value),
   },
   'address[]': {
-    encode: (value) => abiCoder.encodeParameter('address[]', value),
-    decode: (value) => abiCoder.decodeParameter('address[]', value),
+    encode: (value: string[]) => abiCoder.encodeParameter('address[]', value),
+    decode: (value: string) => abiCoder.decodeParameter('address[]', value),
   },
   'uint256[]': {
-    encode: (value) => abiCoder.encodeParameter('uint256[]', value),
-    decode: (value) => abiCoder.decodeParameter('uint256[]', value),
+    encode: (value: Array<number | string>) =>
+      abiCoder.encodeParameter('uint256[]', value),
+    decode: (value: string) => abiCoder.decodeParameter('uint256[]', value),
   },
   'bytes32[]': {
-    encode: (value) => abiCoder.encodeParameter('bytes32[]', value),
-    decode: (value) => abiCoder.decodeParameter('bytes32[]', value),
+    encode: (value: string[]) => abiCoder.encodeParameter('bytes32[]', value),
+    decode: (value: string) => abiCoder.decodeParameter('bytes32[]', value),
+  },
+  'bytes4[]': {
+    encode: (value: string[]) => abiCoder.encodeParameter('bytes4[]', value),
+    decode: (value: string) => abiCoder.decodeParameter('bytes4[]', value),
   },
   'bytes[]': {
-    encode: (value) => abiCoder.encodeParameter('bytes[]', value),
-    decode: (value) => abiCoder.decodeParameter('bytes[]', value),
+    encode: (value: string[]) => abiCoder.encodeParameter('bytes[]', value),
+    decode: (value: string) => abiCoder.decodeParameter('bytes[]', value),
   },
 };
 
@@ -175,8 +185,11 @@ export const valueContentEncodingMap = {
   },
   AssetURL: {
     type: 'custom',
-    encode: (value) =>
-      encodeDataSourceWithHash(value.hashFunction, value.hash, value.url),
+    encode: (value: {
+      hashFunction: SUPPORTED_HASH_FUNCTIONS;
+      hash: string;
+      url: string;
+    }) => encodeDataSourceWithHash(value.hashFunction, value.hash, value.url),
     decode: (value: string) => decodeDataSourceWithHash(value),
   },
   JSONURL: {
@@ -214,7 +227,10 @@ export const valueContentEncodingMap = {
   },
 };
 
-export function encodeValueType(type: string, value: string): string {
+export function encodeValueType(
+  type: string,
+  value: string | string[] | number | number[],
+): string {
   if (!valueTypeEncodingMap[type]) {
     throw new Error('Could not encode valueType: "' + type + '".');
   }
@@ -234,8 +250,21 @@ export function decodeValueType(type: string, value: string) {
 
 export function encodeValueContent(
   type: string,
-  value: string,
-): string | false {
+  value:
+    | string
+    | {
+        hashFunction: SUPPORTED_HASH_FUNCTIONS;
+        hash: string;
+        url: string;
+      },
+):
+  | string
+  | {
+      hashFunction: SUPPORTED_HASH_FUNCTIONS;
+      hash: string;
+      url: string;
+    }
+  | false {
   if (!valueContentEncodingMap[type] && type.substr(0, 2) !== '0x') {
     throw new Error('Could not encode valueContent: "' + type + '".');
   } else if (type.substr(0, 2) === '0x') {

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -21,7 +21,8 @@
   this handles encoding and decoding as per necessary for the erc725 schema specifications
 */
 
-import Web3Abi from 'web3-eth-abi';
+import AbiCoder from 'web3-eth-abi';
+
 import {
   hexToNumber,
   hexToUtf8,
@@ -32,6 +33,7 @@ import {
   toChecksumAddress,
   utf8ToHex,
 } from 'web3-utils';
+
 import { JSONURLDataToEncode } from '../types';
 
 import {
@@ -54,6 +56,10 @@ const encodeDataSourceWithHash = (
   );
 };
 
+// TS can't get the types from the import...
+// @ts-ignore
+const abiCoder: AbiCoder.AbiCoder = AbiCoder;
+
 const decodeDataSourceWithHash = (
   value: string,
 ): { hashFunction: string; hash: string; url: string } => {
@@ -69,65 +75,45 @@ const decodeDataSourceWithHash = (
 
 const valueTypeEncodingMap = {
   string: {
-    // @ts-ignore
-    encode: (value) => Web3Abi.encodeParameter('string', value),
-    // @ts-ignore
-    decode: (value) => Web3Abi.decodeParameter('string', value),
+    encode: (value) => abiCoder.encodeParameter('string', value),
+    decode: (value) => abiCoder.decodeParameter('string', value),
   },
   address: {
-    // @ts-ignore
-    encode: (value) => Web3Abi.encodeParameter('address', value),
-    // @ts-ignore
-    decode: (value) => Web3Abi.decodeParameter('address', value),
+    encode: (value) => abiCoder.encodeParameter('address', value),
+    decode: (value) => abiCoder.decodeParameter('address', value),
   },
   // NOTE: We could add conditional handling of numeric values here...
   uint256: {
-    // @ts-ignore
-    encode: (value) => Web3Abi.encodeParameter('uint256', value),
-    // @ts-ignore
-    decode: (value) => Web3Abi.decodeParameter('uint256', value),
+    encode: (value) => abiCoder.encodeParameter('uint256', value),
+    decode: (value) => abiCoder.decodeParameter('uint256', value),
   },
   bytes32: {
-    // @ts-ignore
-    encode: (value) => Web3Abi.encodeParameter('bytes32', value),
-    // @ts-ignore
-    decode: (value) => Web3Abi.decodeParameter('bytes32', value),
+    encode: (value) => abiCoder.encodeParameter('bytes32', value),
+    decode: (value) => abiCoder.decodeParameter('bytes32', value),
   },
   bytes: {
-    // @ts-ignore
-    encode: (value) => Web3Abi.encodeParameter('bytes', value),
-    // @ts-ignore
-    decode: (value) => Web3Abi.decodeParameter('bytes', value),
+    encode: (value) => abiCoder.encodeParameter('bytes', value),
+    decode: (value) => abiCoder.decodeParameter('bytes', value),
   },
   'string[]': {
-    // @ts-ignore
-    encode: (value) => Web3Abi.encodeParameter('string[]', value),
-    // @ts-ignore
-    decode: (value) => Web3Abi.decodeParameter('string[]', value),
+    encode: (value) => abiCoder.encodeParameter('string[]', value),
+    decode: (value) => abiCoder.decodeParameter('string[]', value),
   },
   'address[]': {
-    // @ts-ignore
-    encode: (value) => Web3Abi.encodeParameter('address[]', value),
-    // @ts-ignore
-    decode: (value) => Web3Abi.decodeParameter('address[]', value),
+    encode: (value) => abiCoder.encodeParameter('address[]', value),
+    decode: (value) => abiCoder.decodeParameter('address[]', value),
   },
   'uint256[]': {
-    // @ts-ignore
-    encode: (value) => Web3Abi.encodeParameter('uint256[]', value),
-    // @ts-ignore
-    decode: (value) => Web3Abi.decodeParameter('uint256[]', value),
+    encode: (value) => abiCoder.encodeParameter('uint256[]', value),
+    decode: (value) => abiCoder.decodeParameter('uint256[]', value),
   },
   'bytes32[]': {
-    // @ts-ignore
-    encode: (value) => Web3Abi.encodeParameter('bytes32[]', value),
-    // @ts-ignore
-    decode: (value) => Web3Abi.decodeParameter('bytes32[]', value),
+    encode: (value) => abiCoder.encodeParameter('bytes32[]', value),
+    decode: (value) => abiCoder.decodeParameter('bytes32[]', value),
   },
   'bytes[]': {
-    // @ts-ignore
-    encode: (value) => Web3Abi.encodeParameter('bytes[]', value),
-    // @ts-ignore
-    decode: (value) => Web3Abi.decodeParameter('bytes[]', value),
+    encode: (value) => abiCoder.encodeParameter('bytes[]', value),
+    decode: (value) => abiCoder.decodeParameter('bytes[]', value),
   },
 };
 
@@ -147,46 +133,45 @@ export const valueContentEncodingMap = {
   },
   Number: {
     type: 'uint256',
-    // NOTE; extra logic is to handle and always return a string number
+    // NOTE: extra logic is to handle and always return a string number
     encode: (value) => {
-      // eslint-disable-next-line no-param-reassign
+      let parsedValue: number;
       try {
-        // eslint-disable-next-line no-param-reassign
-        value = parseInt(value, 10);
-      } catch (error) {
+        parsedValue = parseInt(value, 10);
+      } catch (error: any) {
         throw new Error(error);
       }
 
-      return padLeft(numberToHex(value), 64);
+      return padLeft(numberToHex(parsedValue), 64);
     },
     decode: (value) => '' + hexToNumber(value),
   },
   // NOTE: This is not symmetrical, and always returns a checksummed address
   Address: {
     type: 'address',
-    encode: (value) => {
+    encode: (value: string) => {
       if (isAddress(value)) {
         return value.toLowerCase();
       }
 
       throw new Error('Address: "' + value + '" is an invalid address.');
     },
-    decode: (value) => toChecksumAddress(value),
+    decode: (value: string) => toChecksumAddress(value),
   },
   String: {
     type: 'string',
-    encode: (value) => utf8ToHex(value),
-    decode: (value) => hexToUtf8(value),
+    encode: (value: string) => utf8ToHex(value),
+    decode: (value: string) => hexToUtf8(value),
   },
   Markdown: {
     type: 'string',
-    encode: (value) => utf8ToHex(value),
-    decode: (value) => hexToUtf8(value),
+    encode: (value: string) => utf8ToHex(value),
+    decode: (value: string) => hexToUtf8(value),
   },
   URL: {
     type: 'string',
-    encode: (value) => utf8ToHex(value),
-    decode: (value) => hexToUtf8(value),
+    encode: (value: string) => utf8ToHex(value),
+    decode: (value: string) => hexToUtf8(value),
   },
   AssetURL: {
     type: 'custom',

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -34,7 +34,7 @@ import {
   utf8ToHex,
 } from 'web3-utils';
 
-import { JSONURLDataToEncode } from '../types';
+import { JSONURLDataToEncode, URLDataWithHash } from '../types';
 
 import {
   SUPPORTED_HASH_FUNCTIONS,
@@ -60,9 +60,7 @@ const encodeDataSourceWithHash = (
 // @ts-ignore
 const abiCoder: AbiCoder.AbiCoder = AbiCoder;
 
-const decodeDataSourceWithHash = (
-  value: string,
-): { hashFunction: string; hash: string; url: string } => {
+const decodeDataSourceWithHash = (value: string): URLDataWithHash => {
   const hashFunctionSig = value.substr(0, 10);
   const hashFunction = getHashFunction(hashFunctionSig);
 
@@ -192,6 +190,7 @@ export const valueContentEncodingMap = {
     }) => encodeDataSourceWithHash(value.hashFunction, value.hash, value.url),
     decode: (value: string) => decodeDataSourceWithHash(value),
   },
+  // https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#jsonurl
   JSONURL: {
     type: 'custom',
     encode: (dataToEncode: JSONURLDataToEncode) => {
@@ -202,7 +201,7 @@ export const valueContentEncodingMap = {
       if (json) {
         if (hashFunction) {
           throw new Error(
-            'When passing in the `json` property, we use "keccak256(utf8)" as a hashingFunction at all times',
+            'When passing in the `json` property, we use "keccak256(utf8)" as a default hashingFunction. You do not need to set a `hashFunction`.',
           );
         }
         hashedJson = hashData(
@@ -223,7 +222,7 @@ export const valueContentEncodingMap = {
         url,
       );
     },
-    decode: (dataToDecode) => decodeDataSourceWithHash(dataToDecode),
+    decode: (dataToDecode: string) => decodeDataSourceWithHash(dataToDecode),
   },
 };
 
@@ -256,7 +255,8 @@ export function encodeValueContent(
         hashFunction: SUPPORTED_HASH_FUNCTIONS;
         hash: string;
         url: string;
-      },
+      }
+    | JSONURLDataToEncode,
 ):
   | string
   | {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -82,7 +82,15 @@ export function encodeKeyValue(
     // value type encoding will handle it?
 
     // we handle an array element encoding
-    const results: (string | false)[] = [];
+    const results: (
+      | string
+      | {
+          hashFunction: SUPPORTED_HASH_FUNCTIONS;
+          hash: string;
+          url: string;
+        }
+      | false
+    )[] = [];
     for (let index = 0; index < value.length; index++) {
       const element = value[index];
       results.push(

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -172,7 +172,6 @@ export function transposeArraySchema(
   schema: ERC725JSONSchema,
   index: number,
 ): ERC725ObjectSchema {
-  // Use enum ERC725JSONSchemaKeyType instead?
   if (schema.keyType.toLowerCase() !== 'array') {
     console.error(
       'Schema is not of keyType "Array" for schema: "' + schema.name + '".',
@@ -412,7 +411,7 @@ export function encodeData<
   }, {} as any);
 }
 
-export function getHashFunction(hashFunctionNameOrHash) {
+export function getHashFunction(hashFunctionNameOrHash: string) {
   const hashFunction = HASH_FUNCTIONS[hashFunctionNameOrHash];
 
   if (!hashFunction) {

--- a/src/types/ERC725JSONSchema.ts
+++ b/src/types/ERC725JSONSchema.ts
@@ -18,10 +18,12 @@ export type ERC725JSONSchemaValueType =
   | 'uint256'
   | 'bytes32'
   | 'bytes'
+  | 'bytes4'
   | 'string[]'
   | 'address[]'
   | 'uint256[]'
   | 'bytes32[]'
+  | 'bytes4[]'
   | 'bytes[]';
 
 /**


### PR DESCRIPTION
### What kind of change does this PR introduce?

Add missing types introduced in [LSP6](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-6-KeyManager.md)

### What is the current behaviour? (You can also link to an open issue here)

The `ERC725JSONSchema` interface does not support the latest `keyType` and `valueType`
![image](https://user-images.githubusercontent.com/477945/134737760-1830d5b5-8f04-45bb-9f5c-ff036b2a0c71.png)


### What is the new behaviour (if this is a feature change)?

The interface supports these new types


### Other information

The lib should also be updated to encode/decode these types:

- #38 

Closes #39 