### PR TITLE
fix: wrong return type for fetchData

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,6 @@ export class ERC725<Schema extends GenericSchema> {
    * https://github.com/ERC725Alliance/erc725.js/tree/main/examples/src/getData.js#L43-L56
    * ```
    */
-  async getData(keysOrKeys?: string | string[]);
   async getData(
     keyOrKeys?: string | string[],
   ): Promise<{ [key: string]: any }> {
@@ -203,7 +202,7 @@ export class ERC725<Schema extends GenericSchema> {
    */
   async fetchData(
     keyOrKeys?: string | string[],
-  ): Promise<{ [key: string]: KeyValuePair }> {
+  ): Promise<{ [key: string]: any }> {
     const dataFromChain = await this.getData(keyOrKeys);
     const dataFromExternalSources = await this.getDataFromExternalSources(
       dataFromChain,
@@ -216,7 +215,7 @@ export class ERC725<Schema extends GenericSchema> {
   }
 
   private getDataFromExternalSources(dataFromChain: { [key: string]: any }): {
-    [key: string]: URLDataWithHash;
+    [key: string]: any;
   } {
     return Object.entries(dataFromChain)
       .filter(([key]) => {
@@ -225,7 +224,7 @@ export class ERC725<Schema extends GenericSchema> {
           keySchema.valueContent.toLowerCase(),
         );
       })
-      .reduce(async (accumulator: any, [key, dataEntry]) => {
+      .reduce(async (accumulator, [key, dataEntry]) => {
         let receivedData;
         try {
           const { url } = this.patchIPFSUrlsIfApplicable(dataEntry);


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

bug fix for `fetchData()` return

### What is the current behaviour (you can also link to an open issue here)?

Current types implies following return data:

```js
{
  LSP3Profile: {
    key: 'LSP3Profile', // string
    value: { /* The profile itself */ } //any
  }
}
```

But the return type of `fetchData()` is like this:

```js
{
  LSP3Profile: {
    LSP3Profile: {
      name: 'Name',
      description: '',
      links: [],
      tags: [],
      profileImage: [Array],
      backgroundImage: [Array]
    }
  },
  'SupportedStandards:ERC725Account': '0xafdeb5d6'
}
```

### What is the new behaviour (if this is a feature change)?

Set return type to `any`

### Other information:

Reported by `void` on discord