### PR TITLE
fix: handling of missing keys

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -106,6 +106,50 @@ describe('Running @erc725/erc725.js tests...', () => {
     const ERC725_CONTRACT_ADDRESS =
       '0x320e678bEb3369702EA14555a74414B2C531c510';
 
+    it('should return empty if the key does not exist in the contract', async () => {
+      const erc725 = new ERC725(
+        [
+          {
+            name: 'ThisKeyDoesNotExist',
+            key: '0xb12a0af5f83066646eb63c96bf29dcb827024d9a33189f5a61652a03951d1fbe',
+            keyType: 'Singleton',
+            valueContent: 'String',
+            valueType: 'string',
+          },
+        ],
+        ERC725_CONTRACT_ADDRESS,
+        web3.currentProvider,
+      );
+
+      const data = await erc725.getData('ThisKeyDoesNotExist');
+      assert.deepStrictEqual(data, { ThisKeyDoesNotExist: '' });
+
+      const dataArray = await erc725.getData(['ThisKeyDoesNotExist']);
+      assert.deepStrictEqual(dataArray, { ThisKeyDoesNotExist: '' });
+    });
+
+    it('should return empty if the key of type Array does not exist in the contract', async () => {
+      const erc725 = new ERC725(
+        [
+          {
+            name: 'NonExistingArray[]',
+            key: '0xd6cbdbfc8d25c9ce4720b5fe6fa8fc536803944271617bf5425b4bd579195840',
+            keyType: 'Array',
+            valueContent: 'Address',
+            valueType: 'address',
+          },
+        ],
+        ERC725_CONTRACT_ADDRESS,
+        web3.currentProvider,
+      );
+
+      const data = await erc725.getData('NonExistingArray[]');
+      assert.deepStrictEqual(data, { 'NonExistingArray[]': [] });
+
+      const dataArray = await erc725.getData(['NonExistingArray[]']);
+      assert.deepStrictEqual(dataArray, { 'NonExistingArray[]': [] });
+    });
+
     const e2eSchema: any = [
       {
         name: 'LSP3Profile',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -106,7 +106,7 @@ describe('Running @erc725/erc725.js tests...', () => {
     const ERC725_CONTRACT_ADDRESS =
       '0x320e678bEb3369702EA14555a74414B2C531c510';
 
-    it('should return empty if the key does not exist in the contract', async () => {
+    it('should return null if the key does not exist in the contract', async () => {
       const erc725 = new ERC725(
         [
           {
@@ -122,13 +122,13 @@ describe('Running @erc725/erc725.js tests...', () => {
       );
 
       const data = await erc725.getData('ThisKeyDoesNotExist');
-      assert.deepStrictEqual(data, { ThisKeyDoesNotExist: '' });
+      assert.deepStrictEqual(data, { ThisKeyDoesNotExist: null });
 
       const dataArray = await erc725.getData(['ThisKeyDoesNotExist']);
-      assert.deepStrictEqual(dataArray, { ThisKeyDoesNotExist: '' });
+      assert.deepStrictEqual(dataArray, { ThisKeyDoesNotExist: null });
     });
 
-    it('should return empty if the key of type Array does not exist in the contract', async () => {
+    it('should return [] if the key of type Array does not exist in the contract', async () => {
       const erc725 = new ERC725(
         [
           {

--- a/src/index.ts
+++ b/src/index.ts
@@ -355,7 +355,7 @@ export class ERC725<Schema extends GenericSchema> {
   ) {
     if (schema.keyType !== 'Array') {
       throw new Error(
-        `The "_getArrayFields" method requires a schema definition with "keyType: Array",
+        `The "getArrayValues" method requires a schema definition with "keyType: Array",
          ${schema}`,
       );
     }
@@ -384,12 +384,17 @@ export class ERC725<Schema extends GenericSchema> {
     }
 
     if (this.options.provider.type !== ProviderTypes.GRAPH_QL) {
-      const arrayElements = await this.options.provider?.getAllData(
-        this.options.address as string,
-        arrayElementKeys,
-      );
+      try {
+        const arrayElements = await this.options.provider?.getAllData(
+          this.options.address as string,
+          arrayElementKeys,
+        );
 
-      results.push(...arrayElements);
+        results.push(...arrayElements);
+      } catch (err) {
+        // This case may happen if user requests an array key which does not exist in the contract.
+        // In this case, we simply skip
+      }
 
       return results;
     }
@@ -423,6 +428,7 @@ export class ERC725<Schema extends GenericSchema> {
       const dataKeyValue = {
         [keySchema.key]: { key: keySchema.key, value: rawData },
       };
+
       const arrayValues = await this.getArrayValues(keySchema, dataKeyValue);
 
       if (arrayValues && arrayValues.length > 0) {
@@ -432,7 +438,7 @@ export class ERC725<Schema extends GenericSchema> {
         };
       }
 
-      return {}; // return empty object if there are no arrayValues
+      return { [data]: [] }; // return empty object if there are no arrayValues
     }
 
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -438,7 +438,7 @@ export class ERC725<Schema extends GenericSchema> {
         };
       }
 
-      return { [data]: [] }; // return empty object if there are no arrayValues
+      return { [keySchema.name]: [] }; // return empty object if there are no arrayValues
     }
 
     return {

--- a/src/lib/provider-wrapper-utils.ts
+++ b/src/lib/provider-wrapper-utils.ts
@@ -11,9 +11,25 @@ const web3abiDecoder = abi.default;
 
 export function decodeResult(method: Method, result) {
   const rpcResult = result.result;
-  return rpcResult === '0x'
-    ? null
-    : web3abiDecoder.decodeParameter(METHODS[method].returnEncoding, rpcResult);
+
+  if (rpcResult === '0x') {
+    return null;
+  }
+
+  const decodedData = web3abiDecoder.decodeParameter(
+    METHODS[method].returnEncoding,
+    rpcResult,
+  );
+
+  if (
+    Array.isArray(decodedData) &&
+    decodedData.length === 1 &&
+    decodedData[0] === '0x'
+  ) {
+    return [null];
+  }
+
+  return decodedData;
 }
 
 export function constructJSONRPC(

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -376,7 +376,7 @@ export function decodeKey(schema: ERC725JSONSchema, value) {
       const results: any[] = [];
 
       // If user has requested a key which does not exist in the contract, value will be: 0x and value.find() will fail.
-      if (typeof value === 'string') {
+      if (!value || typeof value === 'string') {
         return results;
       }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -374,6 +374,12 @@ export function decodeKey(schema: ERC725JSONSchema, value) {
   switch (lowerCaseKeyType) {
     case 'array': {
       const results: any[] = [];
+
+      // If user has requested a key which does not exist in the contract, value will be: 0x and value.find() will fail.
+      if (typeof value === 'string') {
+        return results;
+      }
+
       const valueElement = value.find((e) => e.key === schema.key);
       // Handle empty/non-existent array
       if (!valueElement) {

--- a/src/providers/ethereumProviderWrapper.ts
+++ b/src/providers/ethereumProviderWrapper.ts
@@ -25,6 +25,7 @@
 import * as abi from 'web3-eth-abi';
 
 import { ERC725_VERSION, INTERFACE_IDS, METHODS } from '../lib/constants';
+import { decodeResult as decodeResultUtils } from '../lib/provider-wrapper-utils';
 import { Method } from '../types/Method';
 import { ProviderTypes } from '../types/provider';
 
@@ -171,8 +172,6 @@ export class EthereumProviderWrapper {
 
   // eslint-disable-next-line class-methods-use-this
   private decodeResult(method: Method, result: string) {
-    return result === '0x'
-      ? null
-      : web3Abi.decodeParameter(METHODS[method].returnEncoding, result);
+    return decodeResultUtils(method, { result });
   }
 }


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

Fix

### What is the current behaviour (you can also link to an open issue here)?

If user requests a key which is not set in the ERC725Y contract, the function will throw

### What is the new behaviour (if this is a feature change)?

It will return '' or [] and won't throw

### Other information:

Closes #53
