### PR TITLE
fix: empty JSON url return null instead of crash

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -206,6 +206,39 @@ describe('Running @erc725/erc725.js tests...', () => {
     });
   });
 
+  describe('Get/fetch edge cases [mock]', () => {
+    it('should return null if the JSONURL is not set [fetchData]', async () => {
+      const provider = new HttpProvider(
+        {
+          returnData: [
+            {
+              key: '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
+              value:
+                '0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000',
+            },
+          ],
+        },
+        [INTERFACE_IDS.ERC725Y_LEGACY],
+      );
+      const erc725 = new ERC725(
+        [
+          {
+            name: 'LSP3Profile',
+            key: '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
+            keyType: 'Singleton',
+            valueContent: 'JSONURL',
+            valueType: 'bytes',
+          },
+        ],
+        '0x24464DbA7e7781a21eD86133Ebe88Eb9C0762620', // result is mocked so we can use any address
+        provider,
+      );
+
+      const data = await erc725.fetchData('LSP3Profile');
+      assert.deepStrictEqual(data, { LSP3Profile: null });
+    });
+  });
+
   [
     { name: 'legacy', interface: INTERFACE_IDS.ERC725Y_LEGACY },
     { name: 'latest', interface: INTERFACE_IDS.ERC725Y },

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,6 +225,11 @@ export class ERC725<Schema extends GenericSchema> {
         );
       })
       .reduce(async (accumulator, [key, dataEntry]) => {
+        if (!dataEntry) {
+          accumulator[key] = null;
+          return accumulator;
+        }
+
         let receivedData;
         try {
           const { url } = this.patchIPFSUrlsIfApplicable(dataEntry);

--- a/test/mockProviders.ts
+++ b/test/mockProviders.ts
@@ -17,14 +17,15 @@ interface HttpProviderPayload {
 }
 
 export class HttpProvider {
-  public returnData;
+  public returnData: { key: string; value: string }[];
   public supportsInterfaces: string[];
 
-  constructor(props, supportsInterfaces: string[]) {
+  constructor(
+    props: { returnData: { key: string; value: string }[] },
+    supportsInterfaces: string[],
+  ) {
     // clone array
-    this.returnData = Array.isArray(props.returnData)
-      ? [...props.returnData]
-      : props.returnData;
+    this.returnData = [...props.returnData];
     this.supportsInterfaces = supportsInterfaces;
   }
 
@@ -103,18 +104,15 @@ export class HttpProvider {
         case METHODS[Method.GET_DATA_LEGACY].sig:
           {
             const keyParam = '0x' + payload.params[0].data.substr(10);
-            result = Array.isArray(this.returnData)
-              ? this.returnData.find((e) => e.key === keyParam).value
-              : this.returnData;
+            const foundResult = this.returnData.find((e) => e.key === keyParam);
+            result = foundResult ? foundResult.value : '0x';
           }
           break;
         case METHODS[Method.GET_DATA].sig:
           {
             const keyParam = '0x' + payload.params[0].data.substr(138);
-
-            result = Array.isArray(this.returnData)
-              ? this.returnData.find((e) => e.key === keyParam).value
-              : this.returnData;
+            const foundResult = this.returnData.find((e) => e.key === keyParam);
+            result = foundResult ? foundResult.value : '0x';
           }
           break;
         default:


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

Fix

### What is the current behaviour (you can also link to an open issue here)?

If we call fetchData on a JSONURL element with value null, it will throw. Because it will try to load data from non existing url. Cf issue #57 

### What is the new behaviour (if this is a feature change)?

Will simply return null instead of throwing.

### Other information:

Closes #57 
