### PR TITLE
docs: remove deprecated key `SupportedStandards:ERC725Account`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ import Web3 from 'web3';
 // https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-3-UniversalProfile.md
 const schema = [
   {
-    name: 'SupportedStandards:ERC725Account',
-    key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6',
+    name: 'SupportedStandards:LSP3UniversalProfile',
+    key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
     keyType: 'Mapping',
-    valueContent: '0xafdeb5d6',
+    valueContent: '0xabe425d6',
     valueType: 'bytes',
   },
   {
@@ -85,9 +85,9 @@ const erc725 = new ERC725(schema, address, provider, config);
 await erc725.getOwner();
 // > '0x28D25E70819140daF65b724158D00c373D1a18ee'
 
-await erc725.getData('SupportedStandards:ERC725Account');
+await erc725.getData('SupportedStandards:LSP3UniversalProfile');
 /* > {
-  'SupportedStandards:ERC725Account': '0xafdeb5d6'
+  'SupportedStandards:LSP3UniversalProfile': '0xabe425d6'
 }
 */
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,10 +25,10 @@ import Web3 from 'web3';
 // https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-3-UniversalProfile.md
 const schema = [
   {
-    name: 'SupportedStandards:ERC725Account',
-    key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6',
+    name: 'SupportedStandards:LSP3UniversalProfile',
+    key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
     keyType: 'Mapping',
-    valueContent: '0xafdeb5d6',
+    valueContent: '0xabe425d6',
     valueType: 'bytes',
   },
   {
@@ -64,14 +64,14 @@ const erc725 = new ERC725(schema, address, provider, config);
 await erc725.getOwner();
 // > '0x28D25E70819140daF65b724158D00c373D1a18ee'
 
-await erc725.getData('SupportedStandards:ERC725Account');
+await erc725.getData('SupportedStandards:LSP3UniversalProfile');
 /* > 
 {
-  'SupportedStandards:ERC725Account': '0xafdeb5d6'
+  'SupportedStandards:LSP3UniversalProfile': '0xabe425d6'
 }
 */
 
-await erc725.getData(['LSP3Profile', 'SupportedStandards:ERC725Account']);
+await erc725.getData(['LSP3Profile', 'SupportedStandards:LSP3UniversalProfile']);
 /* >
 {
   LSP3Profile: {
@@ -79,7 +79,7 @@ await erc725.getData(['LSP3Profile', 'SupportedStandards:ERC725Account']);
     hash: '0xb4f9d72e83bbe7e250ed9ec80332c493b7b3d73e0d72f7b2c7ab01c39216eb1a',
     hashFunction: 'keccak256(utf8)'
   },
-  'SupportedStandards:ERC725Account': '0xafdeb5d6'
+  'SupportedStandards:LSP3UniversalProfile': '0xabe425d6'
 }
 */
 

--- a/docs/writing-data.md
+++ b/docs/writing-data.md
@@ -25,10 +25,10 @@ import { ERC725 } from '@erc725/erc725.js';
 
 export const schema = [
   {
-    name: 'SupportedStandards:ERC725Account',
-    key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6',
+    name: 'SupportedStandards:LSP3UniversalProfile',
+    key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
     keyType: 'Mapping',
-    valueContent: '0xafdeb5d6',
+    valueContent: '0xabe425d6',
     valueType: 'bytes',
   },
   {

--- a/examples/src/fetchData.js
+++ b/examples/src/fetchData.js
@@ -7,7 +7,7 @@ const myERC725 = getInstance();
 const dataAllKeys = await myERC725.fetchData();
 /*
 {
-  'SupportedStandards:ERC725Account': '0xafdeb5d6',
+  'SupportedStandards:LSP3UniversalProfile': '0xabe425d6',
   LSP3Profile: {
     LSP3Profile: {
       name: 'patrick-mcdowell',

--- a/examples/src/getData.js
+++ b/examples/src/getData.js
@@ -7,7 +7,7 @@ const myERC725 = getInstance();
 const dataAllKeys = await myERC725.getData();
 /*
 {
-  'SupportedStandards:ERC725Account': '0xafdeb5d6',
+  'SupportedStandards:LSP3UniversalProfile': '0xabe425d6',
   LSP3Profile: {
     hashFunction: 'keccak256(utf8)',
     hash: '0xd96ff7776660095f661d16010c4349aa7478a9129ce0670f771596a6ff2d864a',

--- a/examples/src/instantiation.js
+++ b/examples/src/instantiation.js
@@ -12,10 +12,10 @@ const IPFS_GATEWAY = 'https://ipfs.lukso.network/ipfs/';
 export function getInstance() {
   const schema = [
     {
-      name: 'SupportedStandards:ERC725Account',
-      key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6',
+      name: 'SupportedStandards:LSP3UniversalProfile',
+      key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
       keyType: 'Mapping',
-      valueContent: '0xafdeb5d6',
+      valueContent: '0xabe425d6',
       valueType: 'bytes',
     },
     {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -104,7 +104,7 @@ describe('Running @erc725/erc725.js tests...', () => {
     const LEGACY_ERC725_CONTRACT_ADDRESS =
       '0xb8E120e7e5EAe7bfA629Db5CEFfA69C834F74e99';
     const ERC725_CONTRACT_ADDRESS =
-      '0x320e678bEb3369702EA14555a74414B2C531c510';
+      '0x6464C9b995DA466a6fcD50C79D7e9FDd84c74b92';
 
     it('should return null if the key does not exist in the contract', async () => {
       const erc725 = new ERC725(
@@ -150,7 +150,7 @@ describe('Running @erc725/erc725.js tests...', () => {
       assert.deepStrictEqual(dataArray, { 'NonExistingArray[]': [] });
     });
 
-    const e2eSchema: any = [
+    const legacyE2eSchema: any = [
       {
         name: 'LSP3Profile',
         key: '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
@@ -174,7 +174,31 @@ describe('Running @erc725/erc725.js tests...', () => {
       },
     ];
 
-    const e2eResults = {
+    const e2eSchema: any = [
+      {
+        name: 'LSP3Profile',
+        key: '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
+        keyType: 'Singleton',
+        valueContent: 'JSONURL',
+        valueType: 'bytes',
+      },
+      {
+        name: 'SupportedStandards:LSP3UniversalProfile',
+        key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
+        keyType: 'Singleton',
+        valueContent: '0xabe425d6',
+        valueType: 'bytes',
+      },
+      {
+        name: 'LSP1UniversalReceiverDelegate',
+        key: '0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47',
+        keyType: 'Singleton',
+        valueContent: 'Address',
+        valueType: 'address',
+      },
+    ];
+
+    const legacyE2eResults = {
       LSP3Profile: {
         hashFunction: 'keccak256(utf8)',
         hash: '0x70546a2accab18748420b63c63b5af4cf710848ae83afc0c51dd8ad17fb5e8b3',
@@ -185,14 +209,25 @@ describe('Running @erc725/erc725.js tests...', () => {
         '0x36e4Eb6Ee168EF54B1E8e850ACBE51045214B313',
     };
 
+    const e2eResults = {
+      LSP3Profile: {
+        hashFunction: 'keccak256(utf8)',
+        hash: '0xa3c2d57fea7b57208cb7c03858559882fc463d3237865a55be405582d3556962',
+        url: 'ipfs://QmTwdTETBgtPfZT23FwjbT4mfVfig7qit77hACC63idYVH',
+      },
+      'SupportedStandards:LSP3UniversalProfile': '0xabe425d6',
+      LSP1UniversalReceiverDelegate:
+        '0x428e42Be1a13c49c985F2881111f803390B5bF27',
+    };
+
     it('with web3.currentProvider [legacy]', async () => {
       const erc725 = new ERC725<Schema>(
-        e2eSchema,
+        legacyE2eSchema,
         LEGACY_ERC725_CONTRACT_ADDRESS,
         web3.currentProvider,
       );
       const result = await erc725.getData();
-      assert.deepStrictEqual(result, e2eResults);
+      assert.deepStrictEqual(result, legacyE2eResults);
     });
 
     it('with web3.currentProvider', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -150,30 +150,6 @@ describe('Running @erc725/erc725.js tests...', () => {
       assert.deepStrictEqual(dataArray, { 'NonExistingArray[]': [] });
     });
 
-    const legacyE2eSchema: any = [
-      {
-        name: 'LSP3Profile',
-        key: '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
-        keyType: 'Singleton',
-        valueContent: 'JSONURL',
-        valueType: 'bytes',
-      },
-      {
-        name: 'SupportedStandards:ERC725Account',
-        key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6',
-        keyType: 'Singleton',
-        valueContent: '0xafdeb5d6',
-        valueType: 'bytes',
-      },
-      {
-        name: 'LSP1UniversalReceiverDelegate',
-        key: '0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47',
-        keyType: 'Singleton',
-        valueContent: 'Address',
-        valueType: 'address',
-      },
-    ];
-
     const e2eSchema: any = [
       {
         name: 'LSP3Profile',
@@ -198,17 +174,6 @@ describe('Running @erc725/erc725.js tests...', () => {
       },
     ];
 
-    const legacyE2eResults = {
-      LSP3Profile: {
-        hashFunction: 'keccak256(utf8)',
-        hash: '0x70546a2accab18748420b63c63b5af4cf710848ae83afc0c51dd8ad17fb5e8b3',
-        url: 'ipfs://QmecrGejUQVXpW4zS948pNvcnQrJ1KiAoM6bdfrVcWZsn5',
-      },
-      'SupportedStandards:ERC725Account': '0xafdeb5d6',
-      LSP1UniversalReceiverDelegate:
-        '0x36e4Eb6Ee168EF54B1E8e850ACBE51045214B313',
-    };
-
     const e2eResults = {
       LSP3Profile: {
         hashFunction: 'keccak256(utf8)',
@@ -222,12 +187,12 @@ describe('Running @erc725/erc725.js tests...', () => {
 
     it('with web3.currentProvider [legacy]', async () => {
       const erc725 = new ERC725<Schema>(
-        legacyE2eSchema,
+        e2eSchema,
         LEGACY_ERC725_CONTRACT_ADDRESS,
         web3.currentProvider,
       );
       const result = await erc725.getData();
-      assert.deepStrictEqual(result, legacyE2eResults);
+      assert.notDeepStrictEqual(result, e2eResults);
     });
 
     it('with web3.currentProvider', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -104,7 +104,7 @@ describe('Running @erc725/erc725.js tests...', () => {
     const LEGACY_ERC725_CONTRACT_ADDRESS =
       '0xb8E120e7e5EAe7bfA629Db5CEFfA69C834F74e99';
     const ERC725_CONTRACT_ADDRESS =
-      '0x6464C9b995DA466a6fcD50C79D7e9FDd84c74b92';
+      '0x320e678bEb3369702EA14555a74414B2C531c510';
 
     it('should return null if the key does not exist in the contract', async () => {
       const erc725 = new ERC725(
@@ -159,10 +159,10 @@ describe('Running @erc725/erc725.js tests...', () => {
         valueType: 'bytes',
       },
       {
-        name: 'SupportedStandards:LSP3UniversalProfile',
-        key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
+        name: 'SupportedStandards:ERC725Account',
+        key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6',
         keyType: 'Singleton',
-        valueContent: '0xabe425d6',
+        valueContent: '0xafdeb5d6',
         valueType: 'bytes',
       },
       {
@@ -177,12 +177,12 @@ describe('Running @erc725/erc725.js tests...', () => {
     const e2eResults = {
       LSP3Profile: {
         hashFunction: 'keccak256(utf8)',
-        hash: '0xa3c2d57fea7b57208cb7c03858559882fc463d3237865a55be405582d3556962',
-        url: 'ipfs://QmTwdTETBgtPfZT23FwjbT4mfVfig7qit77hACC63idYVH',
+        hash: '0x70546a2accab18748420b63c63b5af4cf710848ae83afc0c51dd8ad17fb5e8b3',
+        url: 'ipfs://QmecrGejUQVXpW4zS948pNvcnQrJ1KiAoM6bdfrVcWZsn5',
       },
-      'SupportedStandards:LSP3UniversalProfile': '0xabe425d6',
+      'SupportedStandards:ERC725Account': '0xafdeb5d6',
       LSP1UniversalReceiverDelegate:
-        '0x428e42Be1a13c49c985F2881111f803390B5bF27',
+        '0x36e4Eb6Ee168EF54B1E8e850ACBE51045214B313',
     };
 
     it('with web3.currentProvider [legacy]', async () => {
@@ -192,7 +192,7 @@ describe('Running @erc725/erc725.js tests...', () => {
         web3.currentProvider,
       );
       const result = await erc725.getData();
-      assert.notDeepStrictEqual(result, e2eResults);
+      assert.deepStrictEqual(result, e2eResults);
     });
 
     it('with web3.currentProvider', async () => {

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -379,7 +379,7 @@ describe('utils', () => {
       },
       {
         keyType: 'Mapping',
-        keyName: 'SupportedStandards:ERC725Account',
+        keyName: 'SupportedStandards:LSP3UniversalProfile',
       },
       {
         keyType: 'Bytes20Mapping',
@@ -413,8 +413,8 @@ describe('utils', () => {
         key: '0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0',
       },
       {
-        keyName: 'SupportedStandards:ERC725Account',
-        key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6',
+        keyName: 'SupportedStandards:LSP3UniversalProfile',
+        key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
       },
       {
         keyName: 'MyCoolAddress:0xcafecafecafecafecafecafecafecafecafecafe',

--- a/test/mockSchema.ts
+++ b/test/mockSchema.ts
@@ -18,16 +18,16 @@ export const mockSchema: (ERC725JSONSchema & {
 })[] = [
   // Case 1
   {
-    name: 'SupportedStandards:ERC725Account',
-    key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6',
+    name: 'SupportedStandards:LSP3UniversalProfile',
+    key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
     keyType: 'Mapping',
-    valueContent: '0xafdeb5d6',
+    valueContent: '0xabe425d6',
     valueType: 'bytes',
     // Testing data
-    returnRawData: abiCoder.encodeParameter('bytes', '0xafdeb5d6'),
-    returnRawDataArray: abiCoder.encodeParameter('bytes[]', ['0xafdeb5d6']),
-    returnGraphData: '0xafdeb5d6',
-    expectedResult: '0xafdeb5d6',
+    returnRawData: abiCoder.encodeParameter('bytes', '0xabe425d6'),
+    returnRawDataArray: abiCoder.encodeParameter('bytes[]', ['0xabe425d6']),
+    returnGraphData: '0xabe425d6',
+    expectedResult: '0xabe425d6',
   },
 
   // Case 2
@@ -578,25 +578,25 @@ export const mockSchema: (ERC725JSONSchema & {
     name: 'MyCoolAddress:0xcafecafecafecafecafecafecafecafecafecafe',
     key: '0x22496f48a493035f00000000cafecafecafecafecafecafecafecafecafecafe',
     keyType: 'Bytes20Mapping',
-    valueContent: '0xafdeb5d6',
+    valueContent: '0xabe425d6',
     valueType: 'bytes',
     // Testing data
-    returnRawData: abiCoder.encodeParameter('bytes', '0xafdeb5d6'),
-    returnRawDataArray: abiCoder.encodeParameter('bytes[]', ['0xafdeb5d6']),
-    returnGraphData: '0xafdeb5d6',
-    expectedResult: '0xafdeb5d6',
+    returnRawData: abiCoder.encodeParameter('bytes', '0xabe425d6'),
+    returnRawDataArray: abiCoder.encodeParameter('bytes[]', ['0xabe425d6']),
+    returnGraphData: '0xabe425d6',
+    expectedResult: '0xabe425d6',
   },
   {
     name: 'AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe',
     key: '0x4b80742d0000000082ac0000cafecafecafecafecafecafecafecafecafecafe',
     keyType: 'Bytes20MappingWithGrouping',
-    valueContent: '0xafdeb5d6',
+    valueContent: '0xabe425d6',
     valueType: 'bytes',
     // Testing data
-    returnRawData: abiCoder.encodeParameter('bytes', '0xafdeb5d6'),
-    returnRawDataArray: abiCoder.encodeParameter('bytes[]', ['0xafdeb5d6']),
-    returnGraphData: '0xafdeb5d6',
-    expectedResult: '0xafdeb5d6',
+    returnRawData: abiCoder.encodeParameter('bytes', '0xabe425d6'),
+    returnRawDataArray: abiCoder.encodeParameter('bytes[]', ['0xabe425d6']),
+    returnGraphData: '0xabe425d6',
+    expectedResult: '0xabe425d6',
   },
 
   // Nested array tests


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

Remove deprecated key `SupportedStandards:ERC725Account`.

### What is the current behaviour (you can also link to an open issue here)?

The code sample use an old deprecated key in the schema and does not return anything for the key `SupportedStandards:`. 

### What is the new behaviour (if this is a feature change)?

- [x] replaced deprecated key `SupportedStandards:ERC725Account` by new key `SupportedStandards:LSP3UniversalProfile`

Changed in:
- README
- md docs page
- js examples


### Other information:

- [x] added schema with `SupportedStandards:ERC725Account` as legacy schema (schema used in _universalprofiles.cloud_






