### PR TITLE
Change release ci

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,4 +1,4 @@
-name: Bump version and create release PR
+name: Bump version
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -56,14 +56,14 @@ jobs:
           labels: |
             automated pr
 
-      # The above Action does not push tag...
       - name: Checkout to PR branch
         uses: actions/checkout@v2
         with:
           ref: bump/${{ env.APP_VERSION }}
 
-      - run: |
-          git push --tags
+      # We purposely not push the tag
+      # The tag will be added when develop is merged into main
+      - run: git push
 
       - name: Check outputs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,16 @@ jobs:
         if: env.SHOULD_RELEASE == 'true'
         run: npm run build
 
+      # We assume this will be always triggered by a merge from develop
+      # Therefore we tag the previous commit (the merge commit won't be on develop)
+      - name: 🏷 Create and push Git Tag
+        if: env.SHOULD_RELEASE == 'true'
+        run: |-
+          git config --global user.email "release@lukso.network"
+          git config --global user.name "LUKSO Bot"
+          git tag -a ${{ env.APP_VERSION }} HEAD~ -m "Release Version ${{ env.APP_VERSION }} [CI]"
+          git push --set-upstream origin tag ${{ env.APP_VERSION }}
+
       # Create GitHub Release
       - name: 📝 Extract release notes from CHANGELOG
         if: env.SHOULD_RELEASE == 'true'
@@ -65,6 +75,17 @@ jobs:
         uses: ffurrer2/extract-release-notes@v1
         with:
           release_notes_file: RELEASENOTES.md
+
+      - uses: jwalton/gh-find-current-pr@v1
+        if: env.SHOULD_RELEASE == 'true'
+        id: findPR
+        with:
+          state: closed
+
+      - name: Add PR body to Release Notes
+        if: env.SHOULD_RELEASE == 'true'
+        run: |-
+          echo ${{ steps.findPR.outputs.body }}|cat - RELEASENOTES.md > /tmp/out && mv /tmp/out RELEASENOTES.md
 
       - name: 🚀 Create GitHub release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

CI update

### What is the current behaviour (you can also link to an open issue here)?

- Tag is pushed on bump
- PR body of a release PR is not added to release notes

### What is the new behaviour (if this is a feature change)?

- Tag is added on merge to main
- Release PR body is added to release body

