### PR TITLE
feat: add encodeKeyName method

### DIFF
--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -620,3 +620,6 @@ ERC725.encodeKeyName('LSP3Profile');
 
 ERC725.encodeKeyName('SupportedStandards:ERC725Account');
 // '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6'
+
+ERC725.encodeKeyName('AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe');
+// '0x4b80742d0000000082ac0000cafecafecafecafecafecafecafecafecafecafe'

--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -588,3 +588,35 @@ erc725.getSchema(
 }
 */
 ```
+
+
+---
+
+## encodeKeyName
+
+```js
+ERC725.encodeKeyName(keyName);
+```
+
+Hashes a key name for use on an [ERC725Y contract](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725y) according to the [LSP2 ERC725Y JSON Schema standard](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md).
+
+This is a static method so does not require an instantiated ERC725 object.
+
+#### Parameters
+
+1. `keyName` - `string`: The key name you want to encode.
+
+#### Returns
+
+`string`
+
+The keccak256 hash of the provided key name. This is the key that must be retrievable from the ERC725Y contract via ERC725Y.getData(bytes32 key).
+
+#### Example
+
+```javascript
+ERC725.encodeKeyName('LSP3Profile');
+// '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5'
+
+ERC725.encodeKeyName('SupportedStandards:ERC725Account');
+// '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6'

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -837,37 +837,118 @@ describe('Running @erc725/erc725.js tests...', () => {
       });
     });
   });
+});
 
-  describe('getSchema', () => {
-    it('should find key in schema used for instantiation', async () => {
-      const schema: ERC725JSONSchema = {
-        name: 'InstantiationSchema',
-        key: '0xdbc90d23b2e4ff291c111a658864f9723a77b8c1f22b707e51a686413948206d',
-        keyType: 'Singleton',
-        valueContent: 'JSONURL',
-        valueType: 'bytes',
-      };
+describe('getSchema', () => {
+  it('should find key in schema used for instantiation', async () => {
+    const schema: ERC725JSONSchema = {
+      name: 'InstantiationSchema',
+      key: '0xdbc90d23b2e4ff291c111a658864f9723a77b8c1f22b707e51a686413948206d',
+      keyType: 'Singleton',
+      valueContent: 'JSONURL',
+      valueType: 'bytes',
+    };
 
-      const erc725 = new ERC725([schema]);
+    const erc725 = new ERC725([schema]);
 
-      const foundSchema = erc725.getSchema(schema.key);
+    const foundSchema = erc725.getSchema(schema.key);
 
-      assert.deepStrictEqual(foundSchema, schema);
+    assert.deepStrictEqual(foundSchema, schema);
+  });
+  it('should find key in schema provided as parameter', async () => {
+    const schema: ERC725JSONSchema = {
+      name: 'ParameterSchema',
+      key: '0x777f55baf2e0c9f73d3bb456dfb8dbf6e609bf557969e3184c17ff925b3c402c',
+      keyType: 'Singleton',
+      valueContent: 'JSONURL',
+      valueType: 'bytes',
+    };
+
+    const erc725 = new ERC725([]);
+
+    const foundSchema = erc725.getSchema(schema.key, [schema]);
+
+    assert.deepStrictEqual(foundSchema, schema);
+  });
+});
+
+describe('encodeKeyName', () => {
+  describe('Singleton', () => {
+    it('Encodes MyKeyName correctly', () => {
+      assert.deepStrictEqual(
+        ERC725.encodeKeyName('MyKeyName'),
+        '0x35e6950bc8d21a1699e58328a3c4066df5803bb0b570d0150cb3819288e764b2',
+      );
     });
-    it('should find key in schema provided as parameter', async () => {
-      const schema: ERC725JSONSchema = {
-        name: 'ParameterSchema',
-        key: '0x777f55baf2e0c9f73d3bb456dfb8dbf6e609bf557969e3184c17ff925b3c402c',
-        keyType: 'Singleton',
-        valueContent: 'JSONURL',
-        valueType: 'bytes',
-      };
-
-      const erc725 = new ERC725([]);
-
-      const foundSchema = erc725.getSchema(schema.key, [schema]);
-
-      assert.deepStrictEqual(foundSchema, schema);
+    it('Encodes LSP3Profile correctly', () => {
+      assert.deepStrictEqual(
+        ERC725.encodeKeyName('LSP3Profile'),
+        '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
+      );
+    });
+  });
+  describe('Array', () => {
+    it('Encodes LSP3IssuedAssets[] correctly', () => {
+      assert.deepStrictEqual(
+        ERC725.encodeKeyName('LSP3IssuedAssets[]'),
+        '0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0',
+      );
+    });
+    it('Encodes LSP5ReceivedAssets[] correctly', () => {
+      assert.deepStrictEqual(
+        ERC725.encodeKeyName('LSP5ReceivedAssets[]'),
+        '0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b',
+      );
+    });
+  });
+  describe('Mapping', () => {
+    it('Encodes SupportedStandards:ERC725Account correctly', () => {
+      assert.deepStrictEqual(
+        ERC725.encodeKeyName('SupportedStandards:ERC725Account'),
+        '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6',
+      );
+    });
+    it('Encodes SupportedStandards:LSP3UniversalProfile correctly', () => {
+      assert.deepStrictEqual(
+        ERC725.encodeKeyName('SupportedStandards:LSP3UniversalProfile'),
+        '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
+      );
+    });
+  });
+  describe('Bytes20Mapping', () => {
+    it('Encodes MyCoolAddress:cafecafecafecafecafecafecafecafecafecafe correctly', () => {
+      assert.deepStrictEqual(
+        ERC725.encodeKeyName(
+          'MyCoolAddress:cafecafecafecafecafecafecafecafecafecafe',
+        ),
+        '0x22496f48a493035f00000000cafecafecafecafecafecafecafecafecafecafe',
+      );
+    });
+    it('Encodes LSP3IssuedAssetsMap:b74a88C43BCf691bd7A851f6603cb1868f6fc147 correctly', () => {
+      assert.deepStrictEqual(
+        ERC725.encodeKeyName(
+          'LSP3IssuedAssetsMap:b74a88C43BCf691bd7A851f6603cb1868f6fc147',
+        ),
+        '0x83f5e77bfb14241600000000b74a88C43BCf691bd7A851f6603cb1868f6fc147',
+      );
+    });
+  });
+  describe('Bytes20MappingWithGrouping', () => {
+    it('Encodes AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe correctly', () => {
+      assert.deepStrictEqual(
+        ERC725.encodeKeyName(
+          'AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe',
+        ),
+        '0x4b80742d0000000082ac0000cafecafecafecafecafecafecafecafecafecafe',
+      );
+    });
+    it('Encodes AddressPermissions:AllowedAddresses:b74a88C43BCf691bd7A851f6603cb1868f6fc147 correctly', () => {
+      assert.deepStrictEqual(
+        ERC725.encodeKeyName(
+          'AddressPermissions:AllowedAddresses:b74a88C43BCf691bd7A851f6603cb1868f6fc147',
+        ),
+        '0x4b80742d00000000c6dd0000b74a88C43BCf691bd7A851f6603cb1868f6fc147',
+      );
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@
  * @date 2020
  */
 
-import { hexToNumber, isAddress, leftPad, toHex } from 'web3-utils';
+import { hexToNumber, isAddress, keccak256, leftPad, toHex } from 'web3-utils';
 
 import { Web3ProviderWrapper } from './providers/web3ProviderWrapper';
 import { EthereumProviderWrapper } from './providers/ethereumProviderWrapper';
@@ -553,6 +553,56 @@ export class ERC725<Schema extends GenericSchema> {
     });
 
     return result;
+  }
+
+  /**
+   * Hashes a key name for use on an ERC725Y contract according to LSP2 ERC725Y JSONSchema standard.
+   *
+   * @param keyName The key name you want to encode.
+   * @link https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md ERC725YJsonSchema standard.
+   * @returns {*} The keccak256 hash of the provided key name. This is the key that must be retrievable from the ERC725Y contract via ERC725Y.getData(bytes32 key).
+   */
+  static encodeKeyName(keyName: string): string {
+    const isMapping = keyName.includes(':');
+
+    if (isMapping) {
+      const words = keyName.split(':');
+
+      const isBytes20Mapping = isAddress(words[words.length - 1]);
+      const isMappingWithGrouping = words.length === 3;
+
+      // Mapping
+      if (!isBytes20Mapping && !isMappingWithGrouping) {
+        return (
+          keccak256(words[0]).slice(0, 34) +
+          '0'.repeat(24) +
+          keccak256(words[1]).slice(2).slice(0, 8)
+        );
+      }
+
+      // Bytes20Mapping
+      if (isBytes20Mapping && !isMappingWithGrouping) {
+        return (
+          keccak256(words[0]).slice(0, 18) +
+          '0'.repeat(8) +
+          words[words.length - 1]
+        );
+      }
+
+      // Bytes20MappingWithGrouping
+      if (isBytes20Mapping && isMappingWithGrouping) {
+        return (
+          keccak256(words[0]).slice(0, 10) +
+          '0'.repeat(8) +
+          keccak256(words[1]).slice(2).slice(0, 4) +
+          '0'.repeat(4) +
+          words[words.length - 1]
+        );
+      }
+    }
+
+    // Array + Singleton
+    return keccak256(keyName);
   }
 }
 


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
feature

### What is the new behaviour (if this is a feature change)?
Adds encodeKeyName methods for encoding key names according to LSP2 JSONSchema standard https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md

### Other information:
Closes #74
