### PR TITLE
fix: update ERC725Y JSON Schemas to latest LSPs specs

### DIFF
--- a/src/lib/schemaParser.test.ts
+++ b/src/lib/schemaParser.test.ts
@@ -67,7 +67,7 @@ describe('schemaParser getSchema', () => {
         key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
         keyType: 'Mapping',
         valueContent: '0xabe425d6',
-        valueType: 'bytes',
+        valueType: 'bytes4',
       });
     });
 
@@ -82,7 +82,7 @@ describe('schemaParser getSchema', () => {
         key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000f4d7faed',
         keyType: 'Mapping',
         valueContent: '0xabe425d6',
-        valueType: 'bytes',
+        valueType: 'bytes4',
       });
     });
   });
@@ -119,7 +119,7 @@ describe('schemaParser getSchema', () => {
         key,
         keyType: 'Bytes20MappingWithGrouping',
         valueContent: 'BitArray',
-        valueType: 'byte32',
+        valueType: 'bytes32',
       });
     });
   });

--- a/src/schemas/LSP3UniversalProfile.json
+++ b/src/schemas/LSP3UniversalProfile.json
@@ -4,7 +4,7 @@
     "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6",
     "keyType": "Mapping",
     "valueContent": "0xabe425d6",
-    "valueType": "bytes"
+    "valueType": "bytes4"
   },
   {
     "name": "LSP3Profile",

--- a/src/schemas/LSP3UniversalProfile.json
+++ b/src/schemas/LSP3UniversalProfile.json
@@ -3,49 +3,49 @@
     "name": "SupportedStandards:LSP3UniversalProfile",
     "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6",
     "keyType": "Mapping",
-    "valueContent": "0xabe425d6",
-    "valueType": "bytes4"
+    "valueType": "bytes4",
+    "valueContent": "0xabe425d6"
   },
   {
     "name": "LSP3Profile",
     "key": "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5",
     "keyType": "Singleton",
-    "valueContent": "JSONURL",
-    "valueType": "bytes"
+    "valueType": "bytes",
+    "valueContent": "JSONURL"
   },
   {
     "name": "LSP3IssuedAssetsMap:<address>",
     "key": "0x83f5e77bfb14241600000000<address>",
     "keyType": "Mapping",
-    "valueContent": "Mixed",
-    "valueType": "bytes"
+    "valueType": "bytes",
+    "valueContent": "Mixed"
   },
   {
     "name": "LSP3IssuedAssets[]",
     "key": "0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0",
     "keyType": "Array",
-    "valueContent": "Address",
-    "valueType": "address"
+    "valueType": "address",
+    "valueContent": "Address"
   },
   {
     "name": "LSP5ReceivedAssetsMap:<address>",
     "key": "0x812c4334633eb81600000000<address>",
     "keyType": "Mapping",
-    "valueContent": "Mixed",
-    "valueType": "bytes"
+    "valueType": "bytes",
+    "valueContent": "Mixed"
   },
   {
     "name": "LSP5ReceivedAssets[]",
     "key": "0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b",
     "keyType": "Array",
-    "valueContent": "Address",
-    "valueType": "address"
+    "valueType": "address",
+    "valueContent": "Address"
   },
   {
     "name": "LSP1UniversalReceiverDelegate",
     "key": "0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47",
     "keyType": "Singleton",
-    "valueContent": "Address",
-    "valueType": "address"
+    "valueType": "address",
+    "valueContent": "Address"
   }
 ]

--- a/src/schemas/LSP4DigitalAsset.json
+++ b/src/schemas/LSP4DigitalAsset.json
@@ -32,8 +32,6 @@
     "key": "0x114bd03b3a46d48759680d81ebb2b414fda7d030a7105a851867accf1c2352e7",
     "keyType": "Array",
     "valueContent": "Number",
-    "valueType": "uint256",
-    "elementValueContent": "Address",
-    "elementValueType": "address"
+    "valueType": "uint256"
   }
 ]

--- a/src/schemas/LSP4DigitalAsset.json
+++ b/src/schemas/LSP4DigitalAsset.json
@@ -3,42 +3,42 @@
     "name": "SupportedStandards:LSP4DigitalAsset",
     "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624",
     "keyType": "Mapping",
-    "valueContent": "0xa4d96624",
-    "valueType": "bytes4"
+    "valueType": "bytes4",
+    "valueContent": "0xa4d96624"
   },
   {
     "name": "LSP4TokenName",
     "key": "0xdeba1e292f8ba88238e10ab3c7f88bd4be4fac56cad5194b6ecceaf653468af1",
     "keyType": "Singleton",
-    "valueContent": "String",
-    "valueType": "string"
+    "valueType": "string",
+    "valueContent": "String"
   },
   {
     "name": "LSP4TokenSymbol",
     "key": "0x2f0a68ab07768e01943a599e73362a0e17a63a72e94dd2e384d2c1d4db932756",
     "keyType": "Singleton",
-    "valueContent": "String",
-    "valueType": "string"
+    "valueType": "string",
+    "valueContent": "String"
   },
   {
     "name": "LSP4Metadata",
     "key": "0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e",
     "keyType": "Singleton",
-    "valueContent": "JSONURL",
-    "valueType": "bytes"
+    "valueType": "bytes",
+    "valueContent": "JSONURL"
   },
   {
     "name": "LSP4Creators[]",
     "key": "0x114bd03b3a46d48759680d81ebb2b414fda7d030a7105a851867accf1c2352e7",
     "keyType": "Array",
-    "valueContent": "Number",
-    "valueType": "uint256"
+    "valueType": "uint256",
+    "valueContent": "Number"
   },
   {
     "name": "LSP4CreatorsMap:<address>",
     "key": "0x6de85eaf5d982b4e00000000<address>",
     "keyType": "Mapping",
-    "valueContent": "Mixed",
-    "valueType": "bytes"
+    "valueType": "bytes",
+    "valueContent": "Mixed"
   }
 ]

--- a/src/schemas/LSP4DigitalAsset.json
+++ b/src/schemas/LSP4DigitalAsset.json
@@ -4,7 +4,7 @@
     "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624",
     "keyType": "Mapping",
     "valueContent": "0xa4d96624",
-    "valueType": "bytes"
+    "valueType": "bytes4"
   },
   {
     "name": "LSP4TokenName",

--- a/src/schemas/LSP4DigitalAsset.json
+++ b/src/schemas/LSP4DigitalAsset.json
@@ -33,5 +33,12 @@
     "keyType": "Array",
     "valueContent": "Number",
     "valueType": "uint256"
+  },
+  {
+    "name": "LSP4CreatorsMap:<address>",
+    "key": "0x6de85eaf5d982b4e00000000<address>",
+    "keyType": "Mapping",
+    "valueContent": "Mixed",
+    "valueType": "bytes"
   }
 ]

--- a/src/schemas/LSP5ReceivedAssets.json
+++ b/src/schemas/LSP5ReceivedAssets.json
@@ -3,14 +3,14 @@
     "name": "LSP5ReceivedAssetsMap:<address>",
     "key": "0x812c4334633eb81600000000<address>",
     "keyType": "Mapping",
-    "valueContent": "Mixed",
-    "valueType": "bytes"
+    "valueType": "bytes",
+    "valueContent": "Mixed"
   },
   {
     "name": "LSP5ReceivedAssets[]",
     "key": "0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b",
     "keyType": "Array",
-    "valueContent": "Address",
-    "valueType": "address"
+    "valueType": "address",
+    "valueContent": "Address"
   }
 ]

--- a/src/schemas/LSP6KeyManager.json
+++ b/src/schemas/LSP6KeyManager.json
@@ -3,35 +3,35 @@
     "name": "AddressPermissions[]",
     "key": "0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3",
     "keyType": "Array",
-    "valueContent": "Address",
-    "valueType": "address"
+    "valueType": "address",
+    "valueContent": "Address"
   },
   {
     "name": "AddressPermissions:Permissions:<address>",
     "key": "0x4b80742d0000000082ac0000<address>",
     "keyType": "Bytes20MappingWithGrouping",
-    "valueContent": "BitArray",
-    "valueType": "bytes32"
+    "valueType": "bytes32",
+    "valueContent": "BitArray"
   },
   {
     "name": "AddressPermissions:AllowedAddresses:<address>",
     "key": "0x4b80742d00000000c6dd0000<address>",
     "keyType": "Bytes20MappingWithGrouping",
-    "valueContent": "Address",
-    "valueType": "address[]"
+    "valueType": "address[]",
+    "valueContent": "Address"
   },
   {
     "name": "AddressPermissions:AllowedFunctions:<address>",
     "key": "0x4b80742d000000008efe0000<address>",
     "keyType": "Bytes20MappingWithGrouping",
-    "valueContent": "Bytes4",
-    "valueType": "bytes4[]"
+    "valueType": "bytes4[]",
+    "valueContent": "Bytes4"
   },
   {
     "name": "AddressPermissions:AllowedStandards:<address>",
     "key": "0x4b80742d000000003efa0000<address>",
     "keyType": "Bytes20MappingWithGrouping",
-    "valueContent": "Bytes4",
-    "valueType": "bytes4[]"
+    "valueType": "bytes4[]",
+    "valueContent": "Bytes4"
   }
 ]

--- a/src/schemas/LSP6KeyManager.json
+++ b/src/schemas/LSP6KeyManager.json
@@ -11,7 +11,7 @@
     "key": "0x4b80742d0000000082ac0000<address>",
     "keyType": "Bytes20MappingWithGrouping",
     "valueContent": "BitArray",
-    "valueType": "byte32"
+    "valueType": "bytes32"
   },
   {
     "name": "AddressPermissions:AllowedAddresses:<address>",


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

- fixes in the ERC725Y JSON schemas (typos + deprecated content in keys)
- added an extra key for LSP4

### What is the current behaviour (you can also link to an open issue here)?

In the ERC725Y JSON schemas, the `SupportedStandards:...` keys used `bytes` as their `valueType`,
This was changed in PR 54 in the LIPs repository: https://github.com/lukso-network/LIPs/pull/54

### What is the new behaviour (if this is a feature change)?

- fixed typo in LSP6 schema: `AddressPermissions:Permissions:<address>` -> `bytes32` (not ~`byte32`~)
- for `SupportedStandards:...` keys, use `bytes4` as their `valueType`.
- add `LSP4CreatorsMap:<address>` key in LSP4 schema

