### PR TITLE
chore!: change fetchData output to non object

### DIFF
--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -197,6 +197,8 @@ To ensure **data authenticity** `fetchData` compares the `hash` of the fetched J
 `Promise`<`Object`\>
 
 Returns the fetched and decoded value depending `valueContent` for the schema element, otherwise works like [`getData()`](#getdata).
+If the input is an array of keys, the values will be returned in an object under their key names.
+If the input is a single key (string), the output will be the value if the key.
 
 #### Example
 
@@ -233,21 +235,22 @@ const dataAllKeys = await erc725.fetchData();
 ```
 
 ```javascript title="One key"
-const dataOneKey = await erc725.fetchData('LSP3Profile');
+const profile = await erc725.fetchData('LSP3Profile');
 /**
 {
   LSP3Profile: {
-    LSP3Profile: {
-      name: 'patrick-mcdowell',
-      links: [Array],
-      description: "Beautiful clothing that doesn't cost the Earth. A sustainable designer based in London Patrick works with brand partners to refocus on systemic change centred around creative education. ",
-      profileImage: [Array],
-      backgroundImage: [Array],
-      tags: [Array]
-    }
+    name: 'patrick-mcdowell',
+    links: [Array],
+    description: "Beautiful clothing that doesn't cost the Earth. A sustainable designer based in London Patrick works with brand partners to refocus on systemic change centred around creative education. ",
+    profileImage: [Array],
+    backgroundImage: [Array],
+    tags: [Array]
   }
 }
 */
+
+const delegate = await erc725.fetchData('LSP1UniversalReceiverDelegate');
+// 0x50A02EF693fF6961A7F9178d1e53CC8BbE1DaD68
 ```
 
 ```javascript title="Many keys"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -278,7 +278,7 @@ describe('Running @erc725/erc725.js tests...', () => {
       );
 
       const data = await erc725.fetchData('LSP3Profile');
-      assert.deepStrictEqual(data, { LSP3Profile: null });
+      assert.deepStrictEqual(data, null);
     });
   });
 
@@ -338,7 +338,7 @@ describe('Running @erc725/erc725.js tests...', () => {
           provider,
         );
         const result = await erc725.fetchData('TestJSONURL');
-        assert.deepStrictEqual(result.TestJSONURL, {
+        assert.deepStrictEqual(result, {
           LSP3Profile: {
             backgroundImage:
               'ipfs://QmZF5pxDJcB8eVvCd74rsXBFXhWL3S1XR5tty2cy1a58Ew',
@@ -380,7 +380,7 @@ describe('Running @erc725/erc725.js tests...', () => {
           },
         );
         const result = await erc725.fetchData('TestJSONURL');
-        assert.deepStrictEqual(result.TestJSONURL, {
+        assert.deepStrictEqual(result, {
           LSP3Profile: {
             backgroundImage:
               'ipfs://QmZF5pxDJcB8eVvCd74rsXBFXhWL3S1XR5tty2cy1a58Ew',
@@ -431,7 +431,7 @@ describe('Running @erc725/erc725.js tests...', () => {
           );
           const result = await erc725.fetchData('TestAssetURL');
           assert.strictEqual(
-            Object.prototype.toString.call(result.TestAssetURL),
+            Object.prototype.toString.call(result),
             '[object Uint8Array]',
           );
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,20 +167,33 @@ export class ERC725<Schema extends GenericSchema> {
    *
    * @param {string} keyOrKeys The name (or the encoded name as the schema ‘key’) of the schema element in the class instance’s schema.
    * @param {ERC725JSONSchema} customSchema An optional custom schema element to use for decoding the returned value. Overrides attached schema of the class instance on this call only.
-   * @returns Returns the fetched and decoded value depending ‘valueContent’ for the schema element, otherwise works like getData
+   * @returns Returns the fetched and decoded value depending ‘valueContent’ for the schema element, otherwise works like getData.
    */
+  async fetchData(keyOrKeys: string): Promise<any>;
+  async fetchData(keyOrKeys: string[]): Promise<{ [key: string]: any }>;
+  async fetchData(keyOrKeys: undefined): Promise<{ [key: string]: any }>;
   async fetchData(
     keyOrKeys?: string | string[],
-  ): Promise<{ [key: string]: any }> {
+  ): Promise<any | { [key: string]: any }> {
     const dataFromChain = await this.getData(keyOrKeys);
     const dataFromExternalSources = await this.getDataFromExternalSources(
       dataFromChain,
     );
 
-    return {
+    const results = {
       ...dataFromChain,
       ...dataFromExternalSources,
     };
+
+    if (typeof keyOrKeys === 'string') {
+      if (Object.prototype.hasOwnProperty.call(results, keyOrKeys)) {
+        return results[keyOrKeys];
+      }
+
+      return null;
+    }
+
+    return results;
   }
 
   /**


### PR DESCRIPTION
BREAKING CHANGE: if `fetchData` is called with a string, the output will be the value itself, not an object anymore.

Before:

```js
const dataOneKey = await erc725.fetchData('LSP3Profile');
/**
{
  LSP3Profile: {
    LSP3Profile: {
      name: 'patrick-mcdowell',
      links: [Array],
      description: "Beautiful clothing that doesn't cost the Earth. A sustainable designer based in London Patrick works with brand partners to refocus on systemic change centred around creative education. ",
      profileImage: [Array],
      backgroundImage: [Array],
      tags: [Array]
    }
  }
}
*/
```

after:

```js
const dataOneKey = await erc725.fetchData('LSP3Profile');
/**
{
  LSP3Profile: {
    name: 'patrick-mcdowell',
    links: [Array],
    description: "Beautiful clothing that doesn't cost the Earth. A sustainable designer based in London Patrick works with brand partners to refocus on systemic change centred around creative education. ",
    profileImage: [Array],
    backgroundImage: [Array],
    tags: [Array]
  }
}
*/
```

Closes #119.