### PR TITLE
feat!: change the output of getData for string input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,36 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [0.11.0](https://github.com/ERC725Alliance/erc725.js/compare/v0.8.0...v0.11.0) (2022-04-05)
-
+## [0.11.0](https://github.com/ERC725Alliance/erc725.js/compare/v0.10.0...v0.11.0) (2022-04-05)
 
 ### ⚠ BREAKING CHANGES
 
-* if fetchData is called with a string, the output will be the value itself, not an object anymore.
-* GraphQL / Apollo has been removed
-
-* test: increase timeout from 5s to 10s
+- the output of getData is not an object anymore, but the value directly if the input is a string.
+- if fetchData is called with a string, the output will be the value itself, not an object anymore.
 
 ### Features
 
-* add encodeKeyName method ([#86](https://github.com/ERC725Alliance/erc725.js/issues/86)) ([7cf43ba](https://github.com/ERC725Alliance/erc725.js/commit/7cf43babbf461a05636d31941237adf94a3d364d))
-* add getSchema ([#85](https://github.com/ERC725Alliance/erc725.js/issues/85)) ([7f677d0](https://github.com/ERC725Alliance/erc725.js/commit/7f677d0b6b08061773a151d2e91a21156ca59f3a))
-* add isValidSignature ([6490751](https://github.com/ERC725Alliance/erc725.js/commit/6490751c009e435ac23eb98e6bfe64d271b85ba4))
-* add LSP1 schema ([4f849da](https://github.com/ERC725Alliance/erc725.js/commit/4f849dac01116e6f019e04fea950b42d2271910b))
-* add schemas at the root and improve docs ([#121](https://github.com/ERC725Alliance/erc725.js/issues/121)) ([e37fb39](https://github.com/ERC725Alliance/erc725.js/commit/e37fb3926bcb682df00c632feb3b3a8b1700d2c0))
-* LSP6 Permissions encoding methods ([#84](https://github.com/ERC725Alliance/erc725.js/issues/84)) ([2e1031a](https://github.com/ERC725Alliance/erc725.js/commit/2e1031a047f19b2fc98104b7df58eecb1424b67f))
-
-
-### Bug Fixes
-
-* empty JSON url return null instead of crash ([#61](https://github.com/ERC725Alliance/erc725.js/issues/61)) ([2d1e417](https://github.com/ERC725Alliance/erc725.js/commit/2d1e417facbc9b2c5b1f4fae62d46b498f3f7603))
-* getSchema array ([#95](https://github.com/ERC725Alliance/erc725.js/issues/95)) ([8ce5ff1](https://github.com/ERC725Alliance/erc725.js/commit/8ce5ff1c81ece3534fd557d978bda4107dfd3809))
-* update ERC725Y JSON Schemas to latest LSPs specs ([#92](https://github.com/ERC725Alliance/erc725.js/issues/92)) ([3485baa](https://github.com/ERC725Alliance/erc725.js/commit/3485baa347cf9a194bd0c4ea2a1e8c61922b63b9))
-* wait until a promise is resolved when using ethereum provider ([5efe641](https://github.com/ERC725Alliance/erc725.js/commit/5efe6414b6e4a4250d8c402baa887a269e6f83ef))
-
-
-* change fetchData output to non object ([1d4d570](https://github.com/ERC725Alliance/erc725.js/commit/1d4d57077a7766b3490477efb20f194fc4e00da4))
-* remove GraphQL support ([#83](https://github.com/ERC725Alliance/erc725.js/issues/83)) ([a0a5e93](https://github.com/ERC725Alliance/erc725.js/commit/a0a5e93bff3e4a5cc759c7b8662f7df523fa484f))
+- add schemas at the root and improve docs ([#121](https://github.com/ERC725Alliance/erc725.js/issues/121)) ([e37fb39](https://github.com/ERC725Alliance/erc725.js/commit/e37fb3926bcb682df00c632feb3b3a8b1700d2c0))
+- change the output of getData for string input ([3592c1b](https://github.com/ERC725Alliance/erc725.js/commit/3592c1bb335e9a1bce824bc3ef8667e98ae9e87e))
 
 ## [0.10.0](https://github.com/ERC725Alliance/erc725.js/compare/v0.9.2...v0.10.0) (2022-03-11)
 

--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -16,13 +16,13 @@ It does the `decoding` and `fetching` of external references for you automatical
 
 #### Parameters
 
-1. `data` - `Object`: An object with one or many properties. The object's keys should match the key names defined in the `schema`, and the value should be the encoded value you want to decode. It will decode the value according to the corresponding schema.
+1. `data` - `Object`: An object with one or many properties. The object's keys should match the key names defined in the `schemas`, and the value should be the encoded value you want to decode. It will decode the value according to the corresponding schemas.
 
 #### Returns
 
 `Object`
 
-Returns decoded data as defined and expected in the schema:
+Returns decoded data as defined and expected in the schemas:
 
 #### Example
 

--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -198,7 +198,7 @@ To ensure **data authenticity** `fetchData` compares the `hash` of the fetched J
 
 Returns the fetched and decoded value depending `valueContent` for the schema element, otherwise works like [`getData()`](#getdata).
 If the input is an array of keys, the values will be returned in an object under their key names.
-If the input is a single key (string), the output will be the value if the key.
+If the input is a single key (string), the output will be the value of the key.
 
 #### Example
 
@@ -302,6 +302,8 @@ If you would like to receive everything in one go, you can use [`fetchData`](ERC
 `Promise`<`Object`\>
 
 An object with schema element key names as properties, with corresponding **decoded** data as values.
+If the input is an array of keys, the values will be returned in an object under their key names.
+If the input is a single key (string), the output will be the value of the key.
 
 #### Example
 
@@ -333,16 +335,17 @@ const dataAllKeys = await erc725.getData();
 ```
 
 ```javascript title="One key"
-const dataOneKey = await erc725.getData('LSP3Profile');
+const LSP3Profile = await erc725.getData('LSP3Profile');
 /**
 {
-  LSP3Profile: {
-    hashFunction: 'keccak256(utf8)',
-    hash: '0xd96ff7776660095f661d16010c4349aa7478a9129ce0670f771596a6ff2d864a',
-    url: 'ipfs://QmbTmcbp8ZW23vkQrqkasMFqNg2z1iP4e3BCUMz9PKDsSV'
-  }
+  hashFunction: 'keccak256(utf8)',
+  hash: '0xd96ff7776660095f661d16010c4349aa7478a9129ce0670f771596a6ff2d864a',
+  url: 'ipfs://QmbTmcbp8ZW23vkQrqkasMFqNg2z1iP4e3BCUMz9PKDsSV'
 }
 */
+
+const delegate = await erc725.getData('LSP1UniversalReceiverDelegate');
+// 0x50A02EF693fF6961A7F9178d1e53CC8BbE1DaD68
 ```
 
 ```javascript title="Many keys"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,7 +27,7 @@ import Web3 from 'web3';
 
 // Part of LSP3-UniversalProfile Schema
 // https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-3-UniversalProfile.md
-const schema = [
+const schemas = [
   {
     name: 'SupportedStandards:LSP3UniversalProfile',
     key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
@@ -59,7 +59,7 @@ const config = {
   ipfsGateway: 'https://ipfs.lukso.network/ipfs/',
 };
 
-const erc725 = new ERC725(schema, address, provider, config);
+const erc725 = new ERC725(schemas, address, provider, config);
 ```
 
 ## Usage

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -126,7 +126,7 @@ After the instance has been created is is still possible to change settings thro
 ```javascript
 myERC725.options.schema = '<schema>' // change schema
 myERC725.options.address '<address>' // change address
-myERC725.options.config.ipfsGateway = '<url>' // used for fetchData(), default: 'https://cloudflare-ipfs.com/ipfs/'
+myERC725.options.ipfsGateway = '<url>' // used for fetchData(), default: 'https://cloudflare-ipfs.com/ipfs/'
 
 // NOTE: ERC725.provider can not be changed
 ```

--- a/docs/writing-data.md
+++ b/docs/writing-data.md
@@ -23,7 +23,7 @@ This package is not capable of writing or relaying data to the blockchain. Howev
 import Web3 from 'web3';
 import { ERC725 } from '@erc725/erc725.js';
 
-export const schema = [
+export const schemas = [
   {
     name: 'SupportedStandards:LSP3UniversalProfile',
     key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
@@ -62,7 +62,7 @@ const config = {
   ipfsGateway: 'https://ipfs.lukso.network/ipfs/',
 };
 
-const myERC725 = new ERC725(schema, address, provider, config);
+const myERC725 = new ERC725(schemas, address, provider, config);
 ```
 
 </p>

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -165,7 +165,7 @@ describe('Running @erc725/erc725.js tests...', () => {
       );
 
       const data = await erc725.getData('ThisKeyDoesNotExist');
-      assert.deepStrictEqual(data, { ThisKeyDoesNotExist: null });
+      assert.deepStrictEqual(data, null);
 
       const dataArray = await erc725.getData(['ThisKeyDoesNotExist']);
       assert.deepStrictEqual(dataArray, { ThisKeyDoesNotExist: null });
@@ -187,7 +187,7 @@ describe('Running @erc725/erc725.js tests...', () => {
       );
 
       const data = await erc725.getData('NonExistingArray[]');
-      assert.deepStrictEqual(data, { 'NonExistingArray[]': [] });
+      assert.deepStrictEqual(data, []);
 
       const dataArray = await erc725.getData(['NonExistingArray[]']);
       assert.deepStrictEqual(dataArray, { 'NonExistingArray[]': [] });
@@ -448,9 +448,7 @@ describe('Running @erc725/erc725.js tests...', () => {
         ]);
         const erc725 = new ERC725(mockSchema, address, provider);
         const result = await erc725.getData(schemaElement.key);
-        assert.deepStrictEqual(result, {
-          [schemaElement.name]: schemaElement.expectedResult,
-        });
+        assert.deepStrictEqual(result, schemaElement.expectedResult);
       });
 
       it(schemaElement.name + ' with ethereumProvider EIP 1193', async () => {
@@ -460,9 +458,7 @@ describe('Running @erc725/erc725.js tests...', () => {
         ]);
         const erc725 = new ERC725(mockSchema, address, provider);
         const result = await erc725.getData(schemaElement.key);
-        assert.deepStrictEqual(result, {
-          [schemaElement.name]: schemaElement.expectedResult,
-        });
+        assert.deepStrictEqual(result, schemaElement.expectedResult);
       });
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,11 +68,10 @@ export { flattenEncodedData, encodeData } from './lib/utils';
  *
  */
 export class ERC725<Schema extends GenericSchema> {
-  options: {
+  options: ERC725Config & {
     schemas: ERC725JSONSchema[];
     address?: string;
     provider?;
-    config: ERC725Config;
   };
 
   /**
@@ -104,10 +103,8 @@ export class ERC725<Schema extends GenericSchema> {
       schemas,
       address,
       provider: this.initializeProvider(provider),
-      config: {
-        ...defaultConfig,
-        ...config,
-      },
+      ...defaultConfig,
+      ...config,
     };
   }
 
@@ -510,10 +507,7 @@ export class ERC725<Schema extends GenericSchema> {
     ) {
       return {
         ...receivedData,
-        url: receivedData.url.replace(
-          'ipfs://',
-          this.options.config.ipfsGateway,
-        ),
+        url: receivedData.url.replace('ipfs://', this.options.ipfsGateway),
       };
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export { flattenEncodedData, encodeData } from './lib/utils';
  */
 export class ERC725<Schema extends GenericSchema> {
   options: {
-    schema: ERC725JSONSchema[];
+    schemas: ERC725JSONSchema[];
     address?: string;
     provider?;
     config: ERC725Config;
@@ -84,7 +84,7 @@ export class ERC725<Schema extends GenericSchema> {
    *
    */
   constructor(
-    schema: ERC725JSONSchema[],
+    schemas: ERC725JSONSchema[],
     address?,
     provider?: any,
     config?: ERC725Config,
@@ -92,7 +92,7 @@ export class ERC725<Schema extends GenericSchema> {
     // NOTE: provider param can be either the provider, or and object with {provider:xxx ,type:xxx}
 
     // TODO: Add check for schema format?
-    if (!schema) {
+    if (!schemas) {
       throw new Error('Missing schema.');
     }
 
@@ -101,7 +101,7 @@ export class ERC725<Schema extends GenericSchema> {
     };
 
     this.options = {
-      schema,
+      schemas,
       address,
       provider: this.initializeProvider(provider),
       config: {
@@ -156,7 +156,7 @@ export class ERC725<Schema extends GenericSchema> {
 
     if (!keyOrKeys) {
       // eslint-disable-next-line no-param-reassign
-      keyOrKeys = this.options.schema.map((element) => element.name);
+      keyOrKeys = this.options.schemas.map((element) => element.name);
     }
 
     if (Array.isArray(keyOrKeys)) {
@@ -236,7 +236,7 @@ export class ERC725<Schema extends GenericSchema> {
   ): ERC725JSONSchema | null | Record<string, ERC725JSONSchema | null> {
     return getSchema(
       keyOrKeys,
-      this.options.schema.concat(providedSchemas || []),
+      this.options.schemas.concat(providedSchemas || []),
     );
   }
 
@@ -245,7 +245,7 @@ export class ERC725<Schema extends GenericSchema> {
   } {
     return Object.entries(dataFromChain)
       .filter(([key]) => {
-        const keySchema = getSchemaElement(this.options.schema, key);
+        const keySchema = getSchemaElement(this.options.schemas, key);
         return ['jsonurl', 'asseturl'].includes(
           keySchema.valueContent.toLowerCase(),
         );
@@ -301,7 +301,7 @@ export class ERC725<Schema extends GenericSchema> {
   encodeData<T extends keyof Schema>(data: {
     [K in T]: Schema[T]['encodeData']['inputTypes'];
   }) {
-    return encodeData<Schema, T>(data, this.options.schema);
+    return encodeData<Schema, T>(data, this.options.schemas);
   }
 
   /**
@@ -320,7 +320,7 @@ export class ERC725<Schema extends GenericSchema> {
   }): {
     [K in T]: Schema[T]['decodeData']['returnValues'];
   } {
-    return decodeData<Schema, T>(data, this.options.schema);
+    return decodeData<Schema, T>(data, this.options.schemas);
   }
 
   /**
@@ -430,7 +430,7 @@ export class ERC725<Schema extends GenericSchema> {
   }
 
   private async getDataSingle(data: string) {
-    const keySchema = getSchemaElement(this.options.schema, data);
+    const keySchema = getSchemaElement(this.options.schemas, data);
     const rawData = await this.options.provider?.getData(
       this.options.address as string,
       keySchema.key,
@@ -457,7 +457,7 @@ export class ERC725<Schema extends GenericSchema> {
 
   private async getDataMultiple(keyNames: string[]) {
     const keyHashes = keyNames.map((keyName) => {
-      const schemaElement = getSchemaElement(this.options.schema, keyName);
+      const schemaElement = getSchemaElement(this.options.schemas, keyName);
       return schemaElement.key;
     });
 
@@ -476,7 +476,7 @@ export class ERC725<Schema extends GenericSchema> {
     );
 
     // Get missing 'Array' fields for all arrays, as necessary
-    const arraySchemas = this.options.schema.filter(
+    const arraySchemas = this.options.schemas.filter(
       (e) => e.keyType.toLowerCase() === 'array',
     );
 
@@ -493,7 +493,7 @@ export class ERC725<Schema extends GenericSchema> {
       }
     }
 
-    return decodeData(tmpData, this.options.schema);
+    return decodeData(tmpData, this.options.schemas);
   }
 
   /**


### PR DESCRIPTION
## ⚠️  BREAKING CHANGE:

the output of `getData` is not an object anymore, but the value directly if the input is a string.

Rename `schema` to `schemas`

Closes #127 
Closes #125 

We should update our tutorials accordingly.