### PR TITLE
docs grammar/styling overhaul

### DIFF
--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # ERC725
 
 ## decodeData
@@ -6,27 +10,29 @@
 erc725.decodeData(data);
 ```
 
-In case you are reading the key-value store from an ERC725 smart-contract key-value store
-without `@erc725/erc725.js` you can use `decodeData` to do the decoding for you.
+If you are reading the key-value store from an ERC725 smart-contract key-value store without the `@erc725/erc725.js` library you can use the `decodeData` function to do the decoding for you.
 
 :::tip
-It is more convenient to use [`fetchData`](ERC725.md#fetchdata).
-It does the `decoding` and `fetching` of external references for you automatically.
+If you want total convenience, it is recommended to use the [`fetchData`](01-ERC725.md#fetchdata) function, which automatically `decodes` and `fetches` external references.
 :::
 
 #### Parameters
 
-1. `data` - `Object`: An object with one or many properties. The object's keys should match the key names defined in the `schemas`, and the value should be the encoded value you want to decode. It will decode the value according to the corresponding schemas.
+| Name   | Type   | Description                            |
+| :----- | :----- | :------------------------------------- |
+| `data` | Object | An object with one or many properties. |
 
-#### Returns
+The object's keys should match the key names defined in the `schemas`, and the value should be the encoded value you want to decode. It will decode the value according to the corresponding schemas.
 
-`Object`
+#### Return Values
 
-Returns decoded data as defined and expected in the schemas:
+| Name          | Type   | Description                                                       |
+| :------------ | :----- | :---------------------------------------------------------------- |
+| `decodedData` | Object | The decoded data as defined and expected in the following schemas |
 
-#### Example
+#### Single-Key Example
 
-```javascript title="Decode one key"
+```javascript title="Decoding an object with one key"
 const decodedDataOneKey = erc725.decodeData({
   LSP3Profile:
     '0x6f357c6a820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361696670733a2f2f516d597231564a4c776572673670456f73636468564775676f3339706136727963455a4c6a7452504466573834554178',
@@ -42,7 +48,9 @@ const decodedDataOneKey = erc725.decodeData({
 */
 ```
 
-```javascript title="Decode multiple keys"
+#### Multi-Key Example
+
+```javascript title="Decoding an object with multiple keys"
 const decodedDataManyKeys = erc725.decodeData({
   LSP3Profile:
     '0x6f357c6a820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361696670733a2f2f516d597231564a4c776572673670456f73636468564775676f3339706136727963455a4c6a7452504466573834554178',
@@ -85,26 +93,28 @@ const decodedDataManyKeys = erc725.decodeData({
 erc725.encodeData(data);
 ```
 
-To be able to store your data on the blockchain, you need to encode it according to your `ERC725JSONSchema`.
-
+The function `encodeData` helps you to encode the data of a smart contract according to your `ERC725JSONSchema` so that you can store the information in smart contracts.
 :::tip
-When encoding JSON it is possible to pass in the JSON object and the URL where it is available publicly.
-The JSON will be hashed with `keccak256`.
+When encoding JSON, it is possible to pass in the JSON object and the URL where it is available publicly. The JSON will be hashed with `keccak256`.
 :::
 
 #### Parameters
 
-1. `data` - `Object`: An object with one or many properties, containing the data that needs to be encoded.
+| Name   | Type   | Description                                                                         |
+| :----- | :----- | :---------------------------------------------------------------------------------- |
+| `data` | Object | An object with one or many properties containing the data that needs to be encoded. |
 
 #### Returns
 
-`Object`
+| Name          | Type   | Description                                                                                     |
+| :------------ | :----- | :---------------------------------------------------------------------------------------------- |
+| `encodedData` | Object | an object with the same keys as the object passed in as a parameter containing the encoded data |
 
-An object with the same keys as the object that was passed in as a parameter containing the encoded data, ready to be stored on the blockchain.
+After the `data` is encoded, the object is ready to be stored in smart contracts.
 
-#### Example
+#### Single-Key Example V1
 
-```javascript title="Encoding object with one key"
+```javascript title="Encoding the object with one key"
 const encodedDataOneKey = erc725.encodeData({
   LSP3Profile: {
     json: profileJson, // check instantiation.js to see the actual JSON
@@ -121,7 +131,9 @@ const encodedDataOneKey = erc725.encodeData({
 */
 ```
 
-```javascript title="Encoding object with one key"
+#### Single-Key Example V2
+
+```javascript title="Encoding the object with one key"
 const encodedDataOneKeyV2 = erc725.encodeData({
   LSP3Profile: {
     hashFunction: 'keccak256(utf8)',
@@ -140,7 +152,9 @@ const encodedDataOneKeyV2 = erc725.encodeData({
 */
 ```
 
-```javascript title="Encoding object with multiple keys"
+#### Multi-Key Example
+
+```javascript title="Encoding the object with multiple keys"
 const encodedDataManyKeys = erc725.encodeData({
   LSP3Profile: {
     hashFunction: 'keccak256(utf8)',
@@ -180,29 +194,35 @@ const encodedDataManyKeys = erc725.encodeData({
 erc725.fetchData(keyOrKeys?);
 ```
 
-Since [`getData`](ERC725.md#getdata) exclusively returns data that is stored on the blockchain, `fetchData` comes in handy.
-Additionally to the data from the blockchain, `fetchData` also returns data from IPFS or HTTP(s) endpoints
-stored as [`JSONURL`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#jsonurl) or [`ASSETURL`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#asseturl).
-
+The `fetchData` function fetches smart contract data and can additionally return [`JSONURL`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#jsonurl) or [`ASSETURL`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#asseturl) data from IPFS, HTTP, or HTTPS endpoints.
 :::info
 To ensure **data authenticity** `fetchData` compares the `hash` of the fetched JSON with the `hash` stored on the blockchain.
 :::
 
 #### Parameters
 
-1. `keyOrKeys?` - `string|string[]`: The name (or the encoded name as the schema ‘key’) of the schema element in the class instance’s schema. If not set, it will fetch all the keys of the schema given at instantiation.
+| Name         | Type                           | Description                                                                                         |
+| :----------- | :----------------------------- | :-------------------------------------------------------------------------------------------------- |
+| `keyOrKeys?` | string or <br/> string[&nbsp;] | The name(s) (or the encoded name(s) as schema key) of the element(s) in the smart contract's schema |
+
+If no key (or keys) are set, the function will fetch all the schema keys given at instantiation.
 
 #### Returns
 
-`Promise`<`Object`\>
+| Name      | Type         | Description                                                      |
+| :-------- | :----------- | :--------------------------------------------------------------- |
+| `Promise` | &ltObject&gt | An object depending on the `valueContent` of the schema element. |
 
-Returns the fetched and decoded value depending `valueContent` for the schema element, otherwise works like [`getData()`](#getdata).
-If the input is an array of keys, the values will be returned in an object under their key names.
-If the input is a single key (string), the output will be the value of the key.
+Besides the `valueContent`, the function works like the [`getData()`](#getdata) function.
+:::info
 
-#### Example
+- If the input is an array of keys, the values will be returned in an object under their key names.
+- If the input is a single key (string), the output will be the value of the key.
+  :::
 
-```javascript title="All keys from schema"
+#### All-Keys Example
+
+```javascript title="Receiving all keys from the schema"
 const dataAllKeys = await erc725.fetchData();
 /**
 {
@@ -234,7 +254,9 @@ const dataAllKeys = await erc725.fetchData();
 */
 ```
 
-```javascript title="One key"
+#### Single-Key Example
+
+```javascript title="Receiving one key from the schema"
 const profile = await erc725.fetchData('LSP3Profile');
 /**
 {
@@ -248,12 +270,13 @@ const profile = await erc725.fetchData('LSP3Profile');
   }
 }
 */
-
 const delegate = await erc725.fetchData('LSP1UniversalReceiverDelegate');
 // 0x50A02EF693fF6961A7F9178d1e53CC8BbE1DaD68
 ```
 
-```javascript title="Many keys"
+#### Multi-Keys Example
+
+```javascript title="Receiving multiple keys from the schema"
 const dataManyKeys = await erc725.fetchData([
   'LSP3Profile',
   'LSP1UniversalReceiverDelegate',
@@ -283,31 +306,38 @@ const dataManyKeys = await erc725.fetchData([
 erc725.getData(keyOrKeys?);
 ```
 
-Gets **decoded data** for one, many or all keys of the specified `ERC725` smart-contract.
-When omitting the `keyOrKeys` parameter, it will get all the keys (as per `ERC725JSONSchema` definition).
-
+The function gets **decoded data** for one, many, or all of the specified `ERC725` smart contract's keys.
+When omitting the `key`or `keys[]` parameter, the function will give back every key (as per `ERC725JSONSchema` definition).
 :::caution
-Data returned by this function does not contain external data of [`JSONURL`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#jsonurl)
-or [`ASSETURL`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#asseturl) schema elements.
 
-If you would like to receive everything in one go, you can use [`fetchData`](ERC725.md#fetchdata).
-:::
+- Data returned by this function does not contain external data of [`JSONURL`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#jsonurl)
+  or [`ASSETURL`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#asseturl) schema elements.
+- If you would like to receive everything in one go, you can use [`fetchData`](01-ERC725.md#fetchdata).
+  :::
 
 #### Parameters
 
-1. `keyOrKeys?` - `string|string[]`: The name (or the encoded name as the schema ‘key’) of the schema element in the class instance’s schema. If not set, it will get all the keys of the schema given at instantiation.
+| Name         | Type                           | Description                                                                                         |
+| :----------- | :----------------------------- | :-------------------------------------------------------------------------------------------------- |
+| `keyOrKeys?` | string or <br/> string[&nbsp;] | The name(s) (or the encoded name(s) as schema key) of the element(s) in the smart contract's schema |
+
+If no keys are set, the function will fetch all the keys of the schema given at instantiation.
 
 #### Returns
 
-`Promise`<`Object`\>
+| Name      | Type         | Description                                                                                       |
+| :-------- | :----------- | :------------------------------------------------------------------------------------------------ |
+| `Promise` | &ltObject&gt | with the schema element key names as properties and the corresponding **decoded** data as values. |
 
-An object with schema element key names as properties, with corresponding **decoded** data as values.
-If the input is an array of keys, the values will be returned in an object under their key names.
-If the input is a single key (string), the output will be the value of the key.
+:::info
 
-#### Example
+- If the input is an array of keys, the values will be returned in an object under their key names.
+- If the input is a single key (string), the output will be the value of the key.
+  :::
 
-```javascript title="All keys from schema"
+#### All-Keys Example
+
+```javascript title="Receiving all keys from the schema"
 const dataAllKeys = await erc725.getData();
 /**
 {
@@ -334,7 +364,9 @@ const dataAllKeys = await erc725.getData();
 */
 ```
 
-```javascript title="One key"
+#### Single-Key Example
+
+```javascript title="Receiving one key from the schema"
 const LSP3Profile = await erc725.getData('LSP3Profile');
 /**
 {
@@ -343,12 +375,13 @@ const LSP3Profile = await erc725.getData('LSP3Profile');
   url: 'ipfs://QmbTmcbp8ZW23vkQrqkasMFqNg2z1iP4e3BCUMz9PKDsSV'
 }
 */
-
 const delegate = await erc725.getData('LSP1UniversalReceiverDelegate');
 // 0x50A02EF693fF6961A7F9178d1e53CC8BbE1DaD68
 ```
 
-```javascript title="Many keys"
+#### Multi-Key Example
+
+```javascript title="Receiving multiple keys from the schema"
 const dataManyKeys = await erc725.getData([
   'LSP3Profile',
   'LSP1UniversalReceiverDelegate',
@@ -370,29 +403,35 @@ const dataManyKeys = await erc725.getData([
 ## getOwner
 
 ```js
-erc725.getOwner(address?);
+erc725.getOwner(address);
 ```
 
-An added utility method which simply returns the owner of the contract.
-Not directly related to ERC725 specifications.
+The function is an added utility method that returns the contract owner and is not directly related to ERC725 specifications.
 
 #### Parameters
 
-1. `address?` - `string`: If not set, it will return the owner of the contract used to initialise the ERC725() class.
+| Name       | Type   | Description                              |
+| :--------- | :----- | :--------------------------------------- |
+| `address?` | string | The contract or EOA address of the owner |
+
+If no address is set, the function will return the owner of the contract used to initialise the ERC725() class.
 
 #### Returns
 
-`Promise`<`any`\>
+| Name      | Type        | Description                              |
+| :-------- | :---------- | :--------------------------------------- |
+| `Promise` | &lt;any&gt; | The contract or EOA address of the owner |
 
+:::info
 The address of the contract owner as stored in the contract.
+:::
 
 #### Example
 
-```javascript
+```javascript title="Receiving the owner address"
 // If no address is set, it will return the owner of the contract used to initialise the ERC725() class.
 await erc725.getOwner();
 // '0x94933413384997F9402cc07a650e8A34d60F437A'
-
 // You can also get the owner of a specific contract by setting the address paramater
 await erc725.getOwner('0x3000783905Cc7170cCCe49a4112Deda952DDBe24');
 // '0x7f1b797b2Ba023Da2482654b50724e92EB5a7091'
@@ -406,23 +445,28 @@ await erc725.getOwner('0x3000783905Cc7170cCCe49a4112Deda952DDBe24');
 ERC725.encodePermissions(permissions);
 ```
 
-Encode permissions into a hexadecimal string as defined by the [LSP6 KeyManager Standard](https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager).
-
+The function encodes permissions into a hexadecimal string as defined by the [LSP6 KeyManager Standard](https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager).
+:::info
 This is a static method so does not require an instantiated ERC725 object.
+:::
 
 #### Parameters
 
-1. `permissions` - `Object`: An object with [LSP6 KeyManager Permissions](../../../../../standards/universal-profile/lsp6-key-manager#-address-permissions) as keys and a `boolean` as value. Any ommited Permissions will default to false.
+| Name          | Type   | Description                                                                   |
+| :------------ | :----- | :---------------------------------------------------------------------------- |
+| `permissions` | Object | An object with [LSP6 KeyManager Permissions] as keys and a `boolean` as value |
+
+Any ommited permissions will default to `false`.
 
 #### Returns
 
-`string`
-
-The permissions encoded as a hexadecimal string as defined by the [LSP6 KeyManager Standard](https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager).
+| Name      | Type   | Description                                                                               |
+| :-------- | :----- | :---------------------------------------------------------------------------------------- |
+| `Promise` | string | The permissions encoded as a hexadecimal string defined by the [LSP6 KeyManager Standard] |
 
 #### Example
 
-```javascript
+```javascript title="Encoding permissions"
 ERC725.encodePermissions({
   CHANGEOWNER: false,
   CHANGEPERMISSIONS: false,
@@ -436,8 +480,6 @@ ERC725.encodePermissions({
   SIGN: false,
 }),
 // '0x0000000000000000000000000000000000000000000000000000000000000110'
-
-
 // Any ommited Permissions will default to false
 ERC725.encodePermissions({
   CHANGEPERMISSIONS: true,
@@ -454,23 +496,26 @@ ERC725.encodePermissions({
 ERC725.decodePermissions(permission);
 ```
 
-Decodes permissions from hexadecimal as defined by the [LSP6 KeyManager Standard](https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager).
-
+The function decodes permissions from hexadecimal defined by the [LSP6 KeyManager Standard](https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager).
+:::info
 This is a static method so does not require an instantiated ERC725 object.
+:::
 
 #### Parameters
 
-1. `permission` - `string`: The encoded permission (32bytes hex).
+| Name         | Type   | Description                          |
+| :----------- | :----- | :----------------------------------- |
+| `permission` | string | The encoded permission (32bytes hex) |
 
 #### Returns
 
-`Object`
-
-Object specifying whether default LSP6 permissions are included in provided hexademical string.
+| Name                | Type   | Description                                                                                        |
+| :------------------ | :----- | :------------------------------------------------------------------------------------------------- |
+| `decodedPermission` | Object | An object specifying whether default LSP6 permissions are included in provided hexademical string. |
 
 #### Example
 
-```javascript
+```javascript title="Decoding permissions"
 ERC725.decodePermissions('0x0000000000000000000000000000000000000000000000000000000000000110'),
 /**
 {
@@ -486,7 +531,6 @@ ERC725.decodePermissions('0x0000000000000000000000000000000000000000000000000000
   SIGN: false,
 }
 */
-
 ERC725.decodePermissions('0x000000000000000000000000000000000000000000000000000000000000000a'),
 /**
 {
@@ -504,35 +548,38 @@ ERC725.decodePermissions('0x0000000000000000000000000000000000000000000000000000
 */
 ```
 
+---
+
 ## getSchema
 
 ```js
-erc725.getSchema(keyOrKeys, providedSchemas?);
+erc725.getSchema(keyOrKeys?, providedSchemas);
 ```
 
-Parses a hashed key or a list of hashed keys and will attempt to return its corresponding [LSP-2 ERC725YJSONSchema](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md) object.
-The function will look for a corresponding key within the schemas:
+The function parses a hashed key or a list of hashed keys and will attempt to return its corresponding [LSP2 ERC725YJSONSchema](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md) object. Additionally, it will look for a corresponding key within the schemas:
 
-- in [`schemas/`](https://github.com/ERC725Alliance/erc725.js/tree/main/schemas) folder (which includes all LUKSO [LSPs](https://github.com/lukso-network/LIPs/tree/main/LSPs))
-- provided at ERC725 initialisation
-- provided in the function call (`providedSchemas`)
+- in the [`schemas`](https://github.com/ERC725Alliance/erc725.js/tree/main/schemas) folder (which includes all [LSPs](https://github.com/lukso-network/LIPs/tree/main/LSPs)),
+- that were provided at ERC725 initialisation, and
+- that were provided in the function call (`providedSchemas`).
 
 #### Parameters
 
-1. `keyOrKeys` - `string|string[]`: The key(s) you are trying to get the schema for.
-2. `providedSchemas` - `ERC725JSONSchema[]` : An array of extra [LSP-2 ERC725YJSONSchema](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md) objects that can be used to find the schema.
+| Name              | Type                           | Description                                                                             |
+| :---------------- | :----------------------------- | :-------------------------------------------------------------------------------------- |
+| `keyOrKeys?`      | string or <br/> string[&nbsp;] | The key(s) you are trying to get the schema for                                         |
+| `providedSchemas` | ERC725JSONSchema[&nbsp;]       | An array of extra [LSP-2 ERC725YJSONSchema] objects that can be used to find the schema |
 
 #### Returns
 
-If `keyOrKeys` is a `string`: `ERC725JSONSchema | null`
+| Name     | Type                | Description                                                                                 |
+| :------- | :------------------ | :------------------------------------------------------------------------------------------ |
+| `result` | ERC725JSONSchema    | If the function has the parameter `keyOrKeys?` is a string and the schema was found         |
+| `result` | Record &ltstring&gt | If the function has the parameter `keyOrKeys?` is a string[&nbsp;] and the schema was found |
+| `result` | null                | If the schema was not found                                                                 |
 
-If `keyOrKeys` is a `string[]`: `Record<string, ERC725JSONSchema | null>`
+#### Example using a predefined LSP3 schema
 
-If the schema of a key is not found, it will return `null`.
-
-#### Example
-
-```javascript
+```javascript title="Parsing the hashed key from the LSP3 schema"
 erc725.getSchema(
   '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
 );
@@ -545,7 +592,6 @@ erc725.getSchema(
   valueType: 'bytes'
 }
 */
-
 erc725.getSchema([
   '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
   '0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000001',
@@ -570,7 +616,9 @@ erc725.getSchema([
 */
 ```
 
-```javascript title="With a custom schema"
+#### Example using a custom schema
+
+```javascript title="Parsing the hashed key from a custom schema"
 erc725.getSchema(
   '0x777f55baf2e0c9f73d3bb456dfb8dbf6e609bf557969e3184c17ff925b3c402c',
   [
@@ -583,7 +631,6 @@ erc725.getSchema(
     },
   ],
 );
-
 /**
 {
   name: 'ParameterSchema',
@@ -603,29 +650,32 @@ erc725.getSchema(
 ERC725.encodeKeyName(keyName);
 ```
 
-Hashes a key name for use on an [ERC725Y contract](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725y) according to the [LSP2 ERC725Y JSON Schema standard](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md).
-
-This is a static method so does not require an instantiated ERC725 object.
+The function hashes a key name for use on an [ERC725Y contract](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725y) according to the [LSP2 ERC725Y JSON Schema Standard](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md).
+:::info
+This is a static method and does not require an instantiated ERC725 object.
+:::
 
 #### Parameters
 
-1. `keyName` - `string`: The key name you want to encode.
+| Name      | Type   | Description                     |
+| :-------- | :----- | :------------------------------ |
+| `keyName` | string | The key name you want to encode |
 
 #### Returns
 
-`string`
+| Name             | Type   | Description                                 |
+| :--------------- | :----- | :------------------------------------------ |
+| `encodedKeyName` | string | The keccak256 hash of the provided key name |
 
-The keccak256 hash of the provided key name. This is the key that must be retrievable from the ERC725Y contract via ERC725Y.getData(bytes32 key).
+The hash must be retrievable from the ERC725Y contract via the [getData](#getdata) function.
 
 #### Example
 
-```javascript
+```javascript title="Encode the key name"
 ERC725.encodeKeyName('LSP3Profile');
 // '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5'
-
 ERC725.encodeKeyName('SupportedStandards:ERC725Account');
 // '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6'
-
 ERC725.encodeKeyName(
   'AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe',
 );
@@ -640,22 +690,37 @@ ERC725.encodeKeyName(
 erc725.isValidSignature(messageOrHash, signature);
 ```
 
-Checks if a signature was signed by the `owner` of the ERC725 Account contract, according to [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271). If the `owner` is a contract itself, it will delegate the `isValidsignature()` call to the owner contract, if it supports [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271), otherwise it will fail.
+The function checks if a signature was signed by the `owner` of the ERC725 Account contract, according to [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271). If the `owner` is a contract itself, it will delegate the `isValidsignature()` call to the owner contract if it supports [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271). Otherwise, the function will fail.
 
 #### Parameters
 
-1. `messageOrHash` - `string`: If the string is not a hash (66 chars long with 0x prefix), it will be enveloped as follows: `"\x19Ethereum Signed Message:\n" + message.length + message` and hashed using keccak256.
-2. `signature` - `string`: The raw RLP encoded signature (can be generated with [`web3.eth.accounts.sign()`](https://web3js.readthedocs.io/en/v1.2.11/web3-eth-accounts.html#sign)).
+| Name            | Type   | Description                                           |
+| :-------------- | :----- | :---------------------------------------------------- |
+| `messageOrHash` | string | value of an message or hash that needs to be verified |
+| `signature`     | string | The raw RLP encoded signature                         |
+
+:::info
+
+- The hash must be 66 chars long with the `0x` prefix, otherwise it will be interpreded as message.
+- The message will be: enveloped as `"\x19Ethereum Signed Message:\n" + message.length + message` <br/> and hashed using `keccak256` function.
+  The signature can be generated with [`web3.eth.accounts.sign()`](https://web3js.readthedocs.io/en/v1.2.11/web3-eth-accounts.html#sign).
+  :::
 
 #### Returns
 
-`Promise<boolean>`
+| Name      | Type          | Description                                                    |
+| :-------- | :------------ | :------------------------------------------------------------- |
+| `Promise` | &ltboolean&gt | `true` if signature is valid, `false` if signature is invalid. |
 
-If the signature is valid (the smart contract response IS the MAGICVALUE: `0x1626ba7e`), it will return `true`. Otherwise, it will return `false`. If this function is called on a contract which does not support [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271), it will throw an error.
+:::info
 
-#### Example
+- A valid signature means that the smart contract response IS the MAGICVALUE: `0x1626ba7e`.
+- If this function is called on a contract which does not support [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271), it will throw an error.
+  :::
 
-```javascript title="with a message"
+#### Examples
+
+```javascript title="Checking the signature with a message"
 await erc725.isValidSignature(
   'hello',
   '0xb91467e570a6466aa9e9876cbcd013baba02900b8979d43fe208a4a4f339f5fd6007e74cd82e037b800186422fc2da167c747ef045e5d18a5f5d4300f8e1a0291c',
@@ -663,10 +728,14 @@ await erc725.isValidSignature(
 // true
 ```
 
-```javascript title="with a hash"
+```javascript title="Checking the signature with a hash"
 await erc725.isValidSignature(
   '0x1da44b586eb0729ff70a73c326926f6ed5a25f5b056e7f47fbc6e58d86871655',
   '0xcafecafeb915466aa9e9876cbcd013baba02900b8979d43fe208a4a4f339f5fd6007e74cd82e037b800186422fc2da167c747ef045e5d18a5f5d4300f8e1a0291c',
 );
 // false
 ```
+
+[lsp6 keymanager permissions]: ../../../../../standards/universal-profile/lsp6-key-manager#-address-permissions
+[lsp6 keymanager standard]: https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager
+[lsp-2 erc725yjsonschema]: https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md

--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -312,7 +312,7 @@ When omitting the `key`or `keys[]` parameter, the function will give back every 
 
 - Data returned by this function does not contain external data of [`JSONURL`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#jsonurl)
   or [`ASSETURL`](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md#asseturl) schema elements.
-- If you would like to receive everything in one go, you can use [`fetchData`](01-ERC725.md#fetchdata).
+- If you would like to receive everything in one go, you can use [`fetchData`](ERC725.md#fetchdata).
   :::
 
 #### Parameters
@@ -702,7 +702,7 @@ The function checks if a signature was signed by the `owner` of the ERC725 Accou
 :::info
 
 - The hash must be 66 chars long with the `0x` prefix, otherwise it will be interpreded as message.
-- The message will be: enveloped as `"\x19Ethereum Signed Message:\n" + message.length + message` <br/> and hashed using `keccak256` function.
+- The message will be: enveloped as `"\x19Ethereum Signed Message:\n" + message.length + message` and hashed using `keccak256` function.
   The signature can be generated with [`web3.eth.accounts.sign()`](https://web3js.readthedocs.io/en/v1.2.11/web3-eth-accounts.html#sign).
   :::
 

--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -10,10 +10,10 @@ sidebar_position: 1
 erc725.decodeData(data);
 ```
 
-If you are reading the key-value store from an ERC725 smart-contract key-value store without the `@erc725/erc725.js` library you can use the `decodeData` function to do the decoding for you.
+If you are reading the key-value store from an ERC725 smart-contract you can use the `decodeData` function to do the decoding for you.
 
 :::tip
-If you want total convenience, it is recommended to use the [`fetchData`](01-ERC725.md#fetchdata) function, which automatically `decodes` and `fetches` external references.
+If you want total convenience, it is recommended to use the [`fetchData`](ERC725.md#fetchdata) function, which automatically `decodes` and `fetches` external references.
 :::
 
 #### Parameters
@@ -112,7 +112,7 @@ When encoding JSON, it is possible to pass in the JSON object and the URL where 
 
 After the `data` is encoded, the object is ready to be stored in smart contracts.
 
-#### Single-Key Example V1
+#### Single-Key Example 1
 
 ```javascript title="Encoding the object with one key"
 const encodedDataOneKey = erc725.encodeData({
@@ -131,7 +131,7 @@ const encodedDataOneKey = erc725.encodeData({
 */
 ```
 
-#### Single-Key Example V2
+#### Single-Key Example 2
 
 ```javascript title="Encoding the object with one key"
 const encodedDataOneKeyV2 = erc725.encodeData({

--- a/docs/classes/_category_.yml
+++ b/docs/classes/_category_.yml
@@ -1,2 +1,3 @@
 label: 'Classes'
 collapsed: true
+position: 5

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,14 +1,14 @@
 ---
-sidebar_position: 1.1
+sidebar_position: 1
 ---
 
 # Getting Started
 
 :::caution
-This package is currently in early stages of development, use only for testing or experimentation purposes.
+This package is currently in the early stages of development. Please use it for testing or experimentation purposes only.
 :::
 
-The `@erc725/erc725.js` package allows you to easily interact with the ERC-725 schemas.
+The `@erc725/erc725.js` package allows you to interact with the ERC-725 schemas easily.
 
 - GitHub repo: https://github.com/ERC725Alliance/erc725.js
 - NPM: https://www.npmjs.com/package/@erc725/erc725.js
@@ -108,9 +108,8 @@ await erc725.fetchData('LSP3Profile'); // downloads and verifies the linked JSON
 */
 ```
 
-:::tip Try it
-https://stackblitz.com/edit/erc725js-instantiation?devtoolsheight=66&file=index.js
-:::
+:::tip Try it out
+You can run the code snippit within your browser using the corresponding [StackBlitz example](https://stackblitz.com/edit/erc725js-instantiation?devtoolsheight=66&file=index.js).
 
 :::note
 Whenever you can you should import `ERC725` via the named export. However currently we are also providing a default export.
@@ -121,7 +120,7 @@ import ERC725 from 'erc725.js';
 
 :::
 
-After the instance has been created is is still possible to change settings through the options property.
+After the instance has been created, it is still possible to change settings through the options property.
 
 ```javascript
 myERC725.options.schema = '<schema>' // change schema

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,17 +1,16 @@
 ---
-sidebar_position: 1.3
+sidebar_position: 3
 ---
 
 # Providers
 
-The provider by which `@erc725/erc725.js` will request blockchain data is set on
-the instantiation of the class, through the configuration object.
+The provider by which `@erc725/erc725.js` will request blockchain data is set on the instantiation of the class through the configuration object.
 
 The following provider types are supported:
 
 ## Web3
 
-This will use the web3 provider available at web3.providers
+The following code snippet will use the web3 provider available at web3.providers from the corresponding `web3` library.
 
 ```javascript
 import Web3 from 'web3';
@@ -23,8 +22,7 @@ const web3provider = new Web3(
 
 ## Ethereum (MetaMask)
 
-This is the provider available at `window.ethereum` injected into a
-compatible web browser from the [Metamask plugin](https://metamask.io/).
+The following code snippet will use the web3 provider available at web3.providers from the corresponding `web3` library.
 
 ```javascript
 const ethereumProvider = window.ethereum;

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -1,16 +1,16 @@
 ---
-sidebar_position: 1.2
+sidebar_position: 2
 ---
 
 # Schemas
 
-The `@erc725/erc725.js` library contains a range standard [LSP ERC725 JSON schemas](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md).
+The `@erc725/erc725.js` library contains a range of standard [LSP ERC725 JSON schemas](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md).
 
 Schemas allow erc725.js to know how to decode and encode data written in an [ERC725Y](https://eips.ethereum.org/EIPS/eip-725) smart contract.
 
-_Quick reference for keys used in schema definitions below see_
-[official
-documentation](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md).
+_A quick reference for keys used in schema definitions can be seen below_
+
+[Official Documentation](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md).
 
 - `name`: An arbitrary name
 - `key`: The sha3 hash of the name

--- a/docs/writing-data.md
+++ b/docs/writing-data.md
@@ -1,20 +1,22 @@
 ---
 sidebar_label: Writing Data
-sidebar_position: 1.4
+sidebar_position: 4
 ---
 
-# How to write data to the key-value store of an ERC725Account
+# Writing Data
 
-This package is not capable of writing or relaying data to the blockchain. However it’s utility methods can be used to prepare data for writing to the blockchain. This will provide information that may provide guidance for doing so.
+#### How to write data to the ERC725Account key-value store?
 
-## Example
+The `erc725.js` library cannot write or relay data to the blockchain. However, developers can use its utility methods to prepare data for writing to the blockchain. This section will provide an guide for using such functionality.
 
-1. Encode data using `encodeData`
-2. Flatten encoded data using `flattenEncodedData`
-3. Get a reference to the desired contract, you will need the ABI (jsonInterface)
-4. Iterate on flattenedData and call `setData`
+## Example Flow
 
-<details><summary>Instantiation omitted for brevity, click here to show it</summary>
+1. Encode the data using the `encodeData` function.
+2. Flatten the encoded data using the `flattenEncodedData` function.
+3. Get a ABI (JSON Interface) of the desired contract, in order to reference it.
+4. Iterate on `flattenedData` and call `setData` on the contract.
+
+<details><summary>Extend instantiation of the contract</summary>
 <br/>
 
 <p>
@@ -69,7 +71,7 @@ const myERC725 = new ERC725(schemas, address, provider, config);
 </details>
 
 ```js
-// 1. Encode data using `encodeData`
+// 1. Encode the data using the `encodeData` function.
 const encodedData = myERC725.encodeData({
   LSP3Profile: {
     hashFunction: 'keccak256(utf8)',
@@ -83,10 +85,10 @@ const encodedData = myERC725.encodeData({
   LSP1UniversalReceiverDelegate: '0x1183790f29BE3cDfD0A102862fEA1a4a30b3AdAb',
 });
 
-// 2. Flatten encoded data using `flattenEncodedData`
+// 2. Flatten the encoded data using the `flattenEncodedData` function.
 const dataToSaveOnChain = flattenEncodedData(encodedDataManyKeys);
 
-// 3. Get a reference to the desired contract
+// 3. Get an ABI (JSON Interface) of the desired contract, in order to reference it.
 const erc725Contract = new web3.eth.Contract(
   [
     // NOTE: We are not loading the full contract ABI, only the function we need
@@ -112,7 +114,7 @@ const erc725Contract = new web3.eth.Contract(
   ERC725_ADDRESS, // replace this with the desired value
 );
 
-// 4. Iterate on flattenedData and call `setData`
+// 4. Iterate on `flattenedData` and call `setData` on the smart contract.
 await Promise.all(
   dataToSaveOnChain.map(async ({ key, value }) => {
     return erc725Contract.methods.setData(key, value).send();


### PR DESCRIPTION
Split off from [docs PR166](https://github.com/lukso-network/docs/pull/166)

Includes:
- Overall grammar work
- applying unified styling
- adding tables for parameters/return values as we do in standard/contract sections
- fixed missing nav position

Explanation of using array[&nbsp;] instead of array[ ]:
Arrays are declared with spaces between brackets to improve clarity, but if you have more than one possible type or a small device, the second bracket gets split up with a line break. That's why we need to use the space symbol to always keep it as one object.

Already applied suggestions from Callum from PR166
