### PR TITLE
`encodeData` should handle both named keys and hash keys

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -2,5 +2,5 @@
   "extension": ["ts"],
   "spec": "**/*.test.ts",
   "require": "ts-node/register",
-  "timeout": 10000
+  "timeout": 20000
 }

--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -26,9 +26,9 @@ The object's keys should match the key names defined in the `schemas`, and the v
 
 #### Return Values
 
-| Name          | Type   | Description                                                       |
-| :------------ | :----- | :---------------------------------------------------------------- |
-| `decodedData` | Object | The decoded data as defined and expected in the following schemas |
+| Name          | Type   | Description                                                        |
+| :------------ | :----- | :----------------------------------------------------------------- |
+| `decodedData` | Object | The decoded data as defined and expected in the following schemas. |
 
 #### Single-Key Example
 
@@ -157,6 +157,7 @@ erc725.encodeData(data);
 ```
 
 The function `encodeData` helps you to encode the data of a smart contract according to your `ERC725JSONSchema` so that you can store the information in smart contracts.
+
 :::tip
 When encoding JSON, it is possible to pass in the JSON object and the URL where it is available publicly. The JSON will be hashed with `keccak256`.
 :::
@@ -167,11 +168,13 @@ When encoding JSON, it is possible to pass in the JSON object and the URL where 
 | :----- | :----- | :---------------------------------------------------------------------------------- |
 | `data` | Object | An object with one or many properties containing the data that needs to be encoded. |
 
+The key can be either the named key (i.e. `LSP3Profile`) or the hashed key (with or without `0x` prefix, i.e. `0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5` or `5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5`).
+
 #### Returns
 
-| Name          | Type   | Description                                                                                     |
-| :------------ | :----- | :---------------------------------------------------------------------------------------------- |
-| `encodedData` | Object | an object with the same keys as the object passed in as a parameter containing the encoded data |
+| Name          | Type   | Description                                                                                      |
+| :------------ | :----- | :----------------------------------------------------------------------------------------------- |
+| `encodedData` | Object | An object with the same keys as the object passed in as a parameter containing the encoded data. |
 
 After the `data` is encoded, the object is ready to be stored in smart contracts.
 
@@ -187,6 +190,38 @@ const encodedDataOneKey = erc725.encodeData({
 /**
 {
   LSP3Profile: {
+    value: '0x6f357c6a2404a2866f05e53e141eb61382a045e53c2fc54831daca9d9e1e039a11f739e1696670733a2f2f516d5154716865424c5a466e5155787535524473387441394a746b78665a714d42636d47643973756b587877526d',
+    key: '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5'
+  }
+}
+*/
+
+// You can also use the hashed key (with or without 0x prefix)
+erc725.encodeData({
+  '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5': {
+    json: profileJson,
+    url: 'ifps://QmQTqheBLZFnQUxu5RDs8tA9JtkxfZqMBcmGd9sukXxwRm',
+  },
+});
+/**
+{
+  0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5: {
+    value: '0x6f357c6a2404a2866f05e53e141eb61382a045e53c2fc54831daca9d9e1e039a11f739e1696670733a2f2f516d5154716865424c5a466e5155787535524473387441394a746b78665a714d42636d47643973756b587877526d',
+    key: '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5'
+  }
+}
+*/
+
+erc725.encodeData({
+  '5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5': {
+    json: profileJson,
+    url: 'ifps://QmQTqheBLZFnQUxu5RDs8tA9JtkxfZqMBcmGd9sukXxwRm',
+  },
+});
+
+/**
+{
+  5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5: {
     value: '0x6f357c6a2404a2866f05e53e141eb61382a045e53c2fc54831daca9d9e1e039a11f739e1696670733a2f2f516d5154716865424c5a466e5155787535524473387441394a746b78665a714d42636d47643973756b587877526d',
     key: '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5'
   }
@@ -267,15 +302,15 @@ This is a static method and does not require an instantiated ERC725 object.
 
 #### Parameters
 
-| Name      | Type   | Description                     |
-| :-------- | :----- | :------------------------------ |
-| `keyName` | string | The key name you want to encode |
+| Name      | Type   | Description                      |
+| :-------- | :----- | :------------------------------- |
+| `keyName` | string | The key name you want to encode. |
 
 #### Returns
 
-| Name             | Type   | Description                                 |
-| :--------------- | :----- | :------------------------------------------ |
-| `encodedKeyName` | string | The keccak256 hash of the provided key name |
+| Name             | Type   | Description                                  |
+| :--------------- | :----- | :------------------------------------------- |
+| `encodedKeyName` | string | The keccak256 hash of the provided key name. |
 
 The hash must be retrievable from the ERC725Y contract via the [getData](#getdata) function.
 
@@ -364,9 +399,9 @@ To ensure **data authenticity** `fetchData` compares the `hash` of the fetched J
 
 #### Parameters
 
-| Name         | Type                           | Description                                                                                         |
-| :----------- | :----------------------------- | :-------------------------------------------------------------------------------------------------- |
-| `keyOrKeys?` | string or <br/> string[&nbsp;] | The name(s) (or the encoded name(s) as schema key) of the element(s) in the smart contract's schema |
+| Name         | Type                           | Description                                                                                          |
+| :----------- | :----------------------------- | :--------------------------------------------------------------------------------------------------- |
+| `keyOrKeys?` | string or <br/> string[&nbsp;] | The name(s) (or the encoded name(s) as schema key) of the element(s) in the smart contract's schema. |
 
 If no key (or keys) are set, the function will fetch all the schema keys given at instantiation.
 
@@ -484,9 +519,9 @@ When omitting the `key`or `keys[]` parameter, the function will give back every 
 
 #### Parameters
 
-| Name         | Type                           | Description                                                                                         |
-| :----------- | :----------------------------- | :-------------------------------------------------------------------------------------------------- |
-| `keyOrKeys?` | string or <br/> string[&nbsp;] | The name(s) (or the encoded name(s) as schema key) of the element(s) in the smart contract's schema |
+| Name         | Type                           | Description                                                                                          |
+| :----------- | :----------------------------- | :--------------------------------------------------------------------------------------------------- |
+| `keyOrKeys?` | string or <br/> string[&nbsp;] | The name(s) (or the encoded name(s) as schema key) of the element(s) in the smart contract's schema. |
 
 If no keys are set, the function will fetch all the keys of the schema given at instantiation.
 
@@ -494,7 +529,7 @@ If no keys are set, the function will fetch all the keys of the schema given at 
 
 | Name      | Type         | Description                                                                                       |
 | :-------- | :----------- | :------------------------------------------------------------------------------------------------ |
-| `Promise` | &ltObject&gt | with the schema element key names as properties and the corresponding **decoded** data as values. |
+| `Promise` | &ltObject&gt | With the schema element key names as properties and the corresponding **decoded** data as values. |
 
 :::info
 
@@ -578,17 +613,17 @@ The function is an added utility method that returns the contract owner and is n
 
 #### Parameters
 
-| Name       | Type   | Description                              |
-| :--------- | :----- | :--------------------------------------- |
-| `address?` | string | The contract or EOA address of the owner |
+| Name       | Type   | Description                               |
+| :--------- | :----- | :---------------------------------------- |
+| `address?` | string | The contract or EOA address of the owner. |
 
 If no address is set, the function will return the owner of the contract used to initialise the ERC725() class.
 
 #### Returns
 
-| Name      | Type        | Description                              |
-| :-------- | :---------- | :--------------------------------------- |
-| `Promise` | &lt;any&gt; | The contract or EOA address of the owner |
+| Name      | Type        | Description                               |
+| :-------- | :---------- | :---------------------------------------- |
+| `Promise` | &lt;any&gt; | The contract or EOA address of the owner. |
 
 :::info
 
@@ -623,18 +658,18 @@ The function parses a hashed key or a list of hashed keys and will attempt to re
 
 #### Parameters
 
-| Name              | Type                           | Description                                                                             |
-| :---------------- | :----------------------------- | :-------------------------------------------------------------------------------------- |
-| `keyOrKeys?`      | string or <br/> string[&nbsp;] | The key(s) you are trying to get the schema for                                         |
-| `providedSchemas` | ERC725JSONSchema[&nbsp;]       | An array of extra [LSP-2 ERC725YJSONSchema] objects that can be used to find the schema |
+| Name              | Type                           | Description                                                                              |
+| :---------------- | :----------------------------- | :--------------------------------------------------------------------------------------- |
+| `keyOrKeys?`      | string or <br/> string[&nbsp;] | The key(s) you are trying to get the schema for.                                         |
+| `providedSchemas` | ERC725JSONSchema[&nbsp;]       | An array of extra [LSP-2 ERC725YJSONSchema] objects that can be used to find the schema. |
 
 #### Returns
 
-| Name     | Type                | Description                                                                                 |
-| :------- | :------------------ | :------------------------------------------------------------------------------------------ |
-| `result` | ERC725JSONSchema    | If the function has the parameter `keyOrKeys?` is a string and the schema was found         |
-| `result` | Record &ltstring&gt | If the function has the parameter `keyOrKeys?` is a string[&nbsp;] and the schema was found |
-| `result` | null                | If the schema was not found                                                                 |
+| Name     | Type                | Description                                                                                  |
+| :------- | :------------------ | :------------------------------------------------------------------------------------------- |
+| `result` | ERC725JSONSchema    | If the function has the parameter `keyOrKeys?` is a string and the schema was found.         |
+| `result` | Record &ltstring&gt | If the function has the parameter `keyOrKeys?` is a string[&nbsp;] and the schema was found. |
+| `result` | null                | If the schema was not found.                                                                 |
 
 #### Example using a predefined LSP3 schema
 
@@ -715,8 +750,8 @@ The function checks if a signature was signed by the `owner` of the ERC725 Accou
 
 | Name            | Type   | Description                                           |
 | :-------------- | :----- | :---------------------------------------------------- |
-| `messageOrHash` | string | value of an message or hash that needs to be verified |
-| `signature`     | string | The raw RLP encoded signature                         |
+| `messageOrHash` | string | Value of a message or hash that needs to be verified. |
+| `signature`     | string | The raw RLP encoded signature.                        |
 
 :::info
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -430,6 +430,7 @@ describe('Running @erc725/erc725.js tests...', () => {
             provider,
           );
           const result = await erc725.fetchData('TestAssetURL');
+
           assert.strictEqual(
             Object.prototype.toString.call(result),
             '[object Uint8Array]',

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -18,6 +18,7 @@ import {
   decodeKeyValue,
   encodeKey,
   decodeKey,
+  encodeData,
 } from './utils';
 
 describe('utils', () => {
@@ -317,6 +318,67 @@ describe('utils', () => {
 
       expectedValues.forEach((expectedValue, index) => {
         assert.strictEqual(encodeArrayKey(key, index), expectedValue);
+      });
+    });
+  });
+
+  describe('encodeData', () => {
+    const schemas: ERC725JSONSchema[] = [
+      {
+        name: 'LSP1UniversalReceiverDelegate',
+        key: '0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47',
+        keyType: 'Singleton',
+        valueType: 'address',
+        valueContent: 'Address',
+      },
+    ];
+
+    const expectedResult = {
+      value: '0x1183790f29be3cdfd0a102862fea1a4a30b3adab',
+      key: '0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47',
+    };
+
+    it('encode data with named key', () => {
+      const encodedDataByNamedKey = encodeData(
+        {
+          LSP1UniversalReceiverDelegate:
+            '0x1183790f29BE3cDfD0A102862fEA1a4a30b3AdAb',
+        },
+        schemas,
+      );
+      assert.deepStrictEqual(encodedDataByNamedKey, {
+        LSP1UniversalReceiverDelegate: expectedResult,
+      });
+    });
+
+    it('encode data with hashed key', () => {
+      const hashedKey =
+        '0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47';
+
+      const encodedDataByHashKey = encodeData(
+        {
+          [hashedKey]: '0x1183790f29BE3cDfD0A102862fEA1a4a30b3AdAb',
+        },
+        schemas,
+      );
+      assert.deepStrictEqual(encodedDataByHashKey, {
+        [hashedKey]: expectedResult,
+      });
+    });
+
+    it('encode data with hashed key without 0x prefix', () => {
+      const hashedKey =
+        '0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47';
+
+      const encodedDataByHashKeyWithout0xPrefix = encodeData(
+        {
+          [hashedKey]: '0x1183790f29BE3cDfD0A102862fEA1a4a30b3AdAb',
+        },
+        schemas,
+      );
+
+      assert.deepStrictEqual(encodedDataByHashKeyWithout0xPrefix, {
+        [hashedKey]: expectedResult,
       });
     });
   });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,6 +20,8 @@
 import {
   checkAddressChecksum,
   isAddress,
+  isHex,
+  isHexStrict,
   keccak256,
   numberToHex,
   padLeft,
@@ -210,23 +212,30 @@ export function encodeKeyName(name: string) {
 /**
  *
  * @param schemas An array of ERC725JSONSchema objects.
- * @param {string} keyOrKeyName A string of either the schema element name, or key.
+ * @param {string} namedOrHashedKey A string of either the schema element name, or hashed key (with or without the 0x prefix).
  *
  * @return The requested schema element from the full array of schemas.
  */
 export function getSchemaElement(
   schemas: ERC725JSONSchema[],
-  keyOrKeyName: string,
+  namedOrHashedKey: string,
 ) {
-  const keyHash =
-    keyOrKeyName.slice(0, 2) === '0x'
-      ? keyOrKeyName
-      : encodeKeyName(keyOrKeyName);
+  let keyHash: string;
+
+  if (isHexStrict(namedOrHashedKey)) {
+    keyHash = namedOrHashedKey;
+  } else if (isHex(namedOrHashedKey)) {
+    keyHash = `0x${namedOrHashedKey}`;
+  } else {
+    keyHash = encodeKeyName(namedOrHashedKey);
+  }
+
   const schemaElement = schemas.find((e) => e.key === keyHash);
+
   if (!schemaElement) {
     throw new Error(
       'No matching schema found for key: "' +
-        keyOrKeyName +
+        namedOrHashedKey +
         '" (' +
         keyHash +
         ').',


### PR DESCRIPTION
Closes #134 

Please check input/output data on the related issue.

The scope of the corresponding issue changed during the dev process - we will merge this as it already adds new features for the input and we will tackle the new output with issue: #140 