### PR TITLE
improvement: add instance versions of static methods

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,6 +38,7 @@
     "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     // OTHER
+    "class-methods-use-this": "off",
     "no-shadow": "off",
     "no-console": "off",
     "import/extensions": ["error", "always", { "ts": "never", "js": "never" }],

--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -97,7 +97,7 @@ The function decodes permissions from hexadecimal defined by the [LSP6 KeyManage
 
 :::info
 
-This is a static method so does not require an instantiated ERC725 object.
+`decodePermissions` is available as either a static or non-static method so can be called without instantiating an ERC725 object.
 
 :::
 
@@ -131,7 +131,40 @@ ERC725.decodePermissions('0x0000000000000000000000000000000000000000000000000000
   SIGN: false,
 }
 */
+
+myERC725.decodePermissions('0x0000000000000000000000000000000000000000000000000000000000000110'),
+/**
+{
+  CHANGEOWNER: false,
+  CHANGEPERMISSIONS: false,
+  ADDPERMISSIONS: false,
+  SETDATA: false,
+  CALL: true,
+  STATICCALL: false,
+  DELEGATECALL: false,
+  DEPLOY: false,
+  TRANSFERVALUE: true,
+  SIGN: false,
+}
+*/
+
 ERC725.decodePermissions('0x000000000000000000000000000000000000000000000000000000000000000a'),
+/**
+{
+  CHANGEOWNER: false,
+  CHANGEPERMISSIONS: true,
+  ADDPERMISSIONS: false,
+  SETDATA: true,
+  CALL: false,
+  STATICCALL: false,
+  DELEGATECALL: false,
+  DEPLOY: false,
+  TRANSFERVALUE: false,
+  SIGN: false,
+}
+*/
+
+myERC725.decodePermissions('0x000000000000000000000000000000000000000000000000000000000000000a'),
 /**
 {
   CHANGEOWNER: false,
@@ -296,7 +329,7 @@ The function hashes a key name for use on an [ERC725Y contract](https://github.c
 
 :::info
 
-This is a static method and does not require an instantiated ERC725 object.
+`encodeKeyName` is available as either a static or non-static method so can be called without instantiating an ERC725 object.
 
 :::
 
@@ -325,6 +358,15 @@ ERC725.encodeKeyName(
   'AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe',
 );
 // '0x4b80742d0000000082ac0000cafecafecafecafecafecafecafecafecafecafe'
+
+myERC725.encodeKeyName('LSP3Profile');
+// '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5'
+myERC725.encodeKeyName('SupportedStandards:ERC725Account');
+// '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6'
+myERC725.encodeKeyName(
+  'AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe',
+);
+// '0x4b80742d0000000082ac0000cafecafecafecafecafecafecafecafecafecafe'
 ```
 
 ---
@@ -339,7 +381,7 @@ The function encodes permissions into a hexadecimal string as defined by the [LS
 
 :::info
 
-This is a static method so does not require an instantiated ERC725 object.
+`encodePermissions` is available as either a static or non-static method so can be called without instantiating an ERC725 object.
 
 :::
 
@@ -373,8 +415,30 @@ ERC725.encodePermissions({
   SIGN: false,
 }),
 // '0x0000000000000000000000000000000000000000000000000000000000000110'
+
+
+myERC725.encodePermissions({
+  CHANGEOWNER: false,
+  CHANGEPERMISSIONS: false,
+  ADDPERMISSIONS: false,
+  SETDATA: false,
+  CALL: true,
+  STATICCALL: false,
+  DELEGATECALL: false,
+  DEPLOY: false,
+  TRANSFERVALUE: true,
+  SIGN: false,
+}),
+// '0x0000000000000000000000000000000000000000000000000000000000000110'
+
 // Any ommited Permissions will default to false
 ERC725.encodePermissions({
+  CHANGEPERMISSIONS: true,
+  SETDATA: true,
+}),
+// '0x000000000000000000000000000000000000000000000000000000000000000a'
+
+myERC725.encodePermissions({
   CHANGEPERMISSIONS: true,
   SETDATA: true,
 }),

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -833,11 +833,17 @@ describe('Running @erc725/erc725.js tests...', () => {
       },
     ];
 
+    const erc725Instance = new ERC725([]);
+
     describe(`encodePermissions`, () => {
       testCases.forEach((testCase) => {
         it(`Encodes ${testCase.hex} permission correctly`, () => {
           assert.deepStrictEqual(
             ERC725.encodePermissions(testCase.permissions),
+            testCase.hex,
+          );
+          assert.deepStrictEqual(
+            erc725Instance.encodePermissions(testCase.permissions),
             testCase.hex,
           );
         });
@@ -846,6 +852,13 @@ describe('Running @erc725/erc725.js tests...', () => {
       it('Defaults permissions to false if not passed', () => {
         assert.deepStrictEqual(
           ERC725.encodePermissions({
+            CHANGEPERMISSIONS: true,
+            SETDATA: true,
+          }),
+          '0x000000000000000000000000000000000000000000000000000000000000000a',
+        );
+        assert.deepStrictEqual(
+          erc725Instance.encodePermissions({
             CHANGEPERMISSIONS: true,
             SETDATA: true,
           }),
@@ -861,11 +874,32 @@ describe('Running @erc725/erc725.js tests...', () => {
             ERC725.decodePermissions(testCase.hex),
             testCase.permissions,
           );
+          assert.deepStrictEqual(
+            erc725Instance.decodePermissions(testCase.hex),
+            testCase.permissions,
+          );
         });
       });
       it(`Decodes 0xfff...fff admin permission correctly`, () => {
         assert.deepStrictEqual(
           ERC725.decodePermissions(
+            '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+          ),
+          {
+            CHANGEOWNER: true,
+            CHANGEPERMISSIONS: true,
+            ADDPERMISSIONS: true,
+            SETDATA: true,
+            CALL: true,
+            STATICCALL: true,
+            DELEGATECALL: true,
+            DEPLOY: true,
+            TRANSFERVALUE: true,
+            SIGN: true,
+          },
+        );
+        assert.deepStrictEqual(
+          erc725Instance.decodePermissions(
             '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
           ),
           {
@@ -920,16 +954,26 @@ describe('getSchema', () => {
 });
 
 describe('encodeKeyName', () => {
+  const erc725Instance = new ERC725([]);
+
   describe('Singleton', () => {
     it('Encodes MyKeyName correctly', () => {
       assert.deepStrictEqual(
         ERC725.encodeKeyName('MyKeyName'),
         '0x35e6950bc8d21a1699e58328a3c4066df5803bb0b570d0150cb3819288e764b2',
       );
+      assert.deepStrictEqual(
+        erc725Instance.encodeKeyName('MyKeyName'),
+        '0x35e6950bc8d21a1699e58328a3c4066df5803bb0b570d0150cb3819288e764b2',
+      );
     });
     it('Encodes LSP3Profile correctly', () => {
       assert.deepStrictEqual(
         ERC725.encodeKeyName('LSP3Profile'),
+        '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
+      );
+      assert.deepStrictEqual(
+        erc725Instance.encodeKeyName('LSP3Profile'),
         '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
       );
     });
@@ -940,10 +984,18 @@ describe('encodeKeyName', () => {
         ERC725.encodeKeyName('LSP3IssuedAssets[]'),
         '0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0',
       );
+      assert.deepStrictEqual(
+        erc725Instance.encodeKeyName('LSP3IssuedAssets[]'),
+        '0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0',
+      );
     });
     it('Encodes LSP5ReceivedAssets[] correctly', () => {
       assert.deepStrictEqual(
         ERC725.encodeKeyName('LSP5ReceivedAssets[]'),
+        '0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b',
+      );
+      assert.deepStrictEqual(
+        erc725Instance.encodeKeyName('LSP5ReceivedAssets[]'),
         '0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b',
       );
     });
@@ -954,10 +1006,18 @@ describe('encodeKeyName', () => {
         ERC725.encodeKeyName('SupportedStandards:ERC725Account'),
         '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6',
       );
+      assert.deepStrictEqual(
+        erc725Instance.encodeKeyName('SupportedStandards:ERC725Account'),
+        '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6',
+      );
     });
     it('Encodes SupportedStandards:LSP3UniversalProfile correctly', () => {
       assert.deepStrictEqual(
         ERC725.encodeKeyName('SupportedStandards:LSP3UniversalProfile'),
+        '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
+      );
+      assert.deepStrictEqual(
+        erc725Instance.encodeKeyName('SupportedStandards:LSP3UniversalProfile'),
         '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
       );
     });
@@ -970,10 +1030,22 @@ describe('encodeKeyName', () => {
         ),
         '0x22496f48a493035f00000000cafecafecafecafecafecafecafecafecafecafe',
       );
+      assert.deepStrictEqual(
+        erc725Instance.encodeKeyName(
+          'MyCoolAddress:cafecafecafecafecafecafecafecafecafecafe',
+        ),
+        '0x22496f48a493035f00000000cafecafecafecafecafecafecafecafecafecafe',
+      );
     });
     it('Encodes LSP3IssuedAssetsMap:b74a88C43BCf691bd7A851f6603cb1868f6fc147 correctly', () => {
       assert.deepStrictEqual(
         ERC725.encodeKeyName(
+          'LSP3IssuedAssetsMap:b74a88C43BCf691bd7A851f6603cb1868f6fc147',
+        ),
+        '0x83f5e77bfb14241600000000b74a88C43BCf691bd7A851f6603cb1868f6fc147',
+      );
+      assert.deepStrictEqual(
+        erc725Instance.encodeKeyName(
           'LSP3IssuedAssetsMap:b74a88C43BCf691bd7A851f6603cb1868f6fc147',
         ),
         '0x83f5e77bfb14241600000000b74a88C43BCf691bd7A851f6603cb1868f6fc147',
@@ -988,10 +1060,22 @@ describe('encodeKeyName', () => {
         ),
         '0x4b80742d0000000082ac0000cafecafecafecafecafecafecafecafecafecafe',
       );
+      assert.deepStrictEqual(
+        erc725Instance.encodeKeyName(
+          'AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe',
+        ),
+        '0x4b80742d0000000082ac0000cafecafecafecafecafecafecafecafecafecafe',
+      );
     });
     it('Encodes AddressPermissions:AllowedAddresses:b74a88C43BCf691bd7A851f6603cb1868f6fc147 correctly', () => {
       assert.deepStrictEqual(
         ERC725.encodeKeyName(
+          'AddressPermissions:AllowedAddresses:b74a88C43BCf691bd7A851f6603cb1868f6fc147',
+        ),
+        '0x4b80742d00000000c6dd0000b74a88C43BCf691bd7A851f6603cb1868f6fc147',
+      );
+      assert.deepStrictEqual(
+        erc725Instance.encodeKeyName(
           'AddressPermissions:AllowedAddresses:b74a88C43BCf691bd7A851f6603cb1868f6fc147',
         ),
         '0x4b80742d00000000c6dd0000b74a88C43BCf691bd7A851f6603cb1868f6fc147',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -376,7 +376,7 @@ describe('Running @erc725/erc725.js tests...', () => {
           address,
           provider,
           {
-            ipfsGateway: 'https://ipfs.lukso.network/ipfs/',
+            ipfsGateway: 'https://ipfs.infura.io/ipfs/',
           },
         );
         const result = await erc725.fetchData('TestJSONURL');

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ import {
   SUPPORTED_HASH_FUNCTION_STRINGS,
 } from './lib/constants';
 import { URLDataWithHash, KeyValuePair } from './types';
+import { Permissions } from './types/Method';
 
 export {
   ERC725JSONSchema,
@@ -556,18 +557,7 @@ export class ERC725<Schema extends GenericSchema> {
    * @param permissions The permissions you want to specify to be included or excluded. Any ommitted permissions will default to false.
    * @returns {*} The permissions encoded as a hexadecimal string as defined by the LSP6 Standard.
    */
-  static encodePermissions(permissions: {
-    CHANGEOWNER?: boolean;
-    CHANGEPERMISSIONS?: boolean;
-    ADDPERMISSIONS?: boolean;
-    SETDATA?: boolean;
-    CALL?: boolean;
-    STATICCALL?: boolean;
-    DELEGATECALL?: boolean;
-    DEPLOY?: boolean;
-    TRANSFERVALUE?: boolean;
-    SIGN?: boolean;
-  }): string {
+  static encodePermissions(permissions: Permissions): string {
     const result = Object.keys(permissions).reduce((previous, key) => {
       return permissions[key]
         ? previous + hexToNumber(LSP6_DEFAULT_PERMISSIONS[key])
@@ -584,18 +574,7 @@ export class ERC725<Schema extends GenericSchema> {
    * @param permissions The permissions you want to specify to be included or excluded. Any ommitted permissions will default to false.
    * @returns {*} The permissions encoded as a hexadecimal string as defined by the LSP6 Standard.
    */
-  encodePermissions(permissions: {
-    CHANGEOWNER?: boolean;
-    CHANGEPERMISSIONS?: boolean;
-    ADDPERMISSIONS?: boolean;
-    SETDATA?: boolean;
-    CALL?: boolean;
-    STATICCALL?: boolean;
-    DELEGATECALL?: boolean;
-    DEPLOY?: boolean;
-    TRANSFERVALUE?: boolean;
-    SIGN?: boolean;
-  }): string {
+  encodePermissions(permissions: Permissions): string {
     return ERC725.encodePermissions(permissions);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -578,6 +578,28 @@ export class ERC725<Schema extends GenericSchema> {
   }
 
   /**
+   * Encode permissions into a hexadecimal string as defined by the LSP6 KeyManager Standard.
+   *
+   * @link https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-6-KeyManager.md LSP6 KeyManager Standard.
+   * @param permissions The permissions you want to specify to be included or excluded. Any ommitted permissions will default to false.
+   * @returns {*} The permissions encoded as a hexadecimal string as defined by the LSP6 Standard.
+   */
+  encodePermissions(permissions: {
+    CHANGEOWNER?: boolean;
+    CHANGEPERMISSIONS?: boolean;
+    ADDPERMISSIONS?: boolean;
+    SETDATA?: boolean;
+    CALL?: boolean;
+    STATICCALL?: boolean;
+    DELEGATECALL?: boolean;
+    DEPLOY?: boolean;
+    TRANSFERVALUE?: boolean;
+    SIGN?: boolean;
+  }): string {
+    return ERC725.encodePermissions(permissions);
+  }
+
+  /**
    * Decodes permissions from hexadecimal as defined by the LSP6 KeyManager Standard.
    *
    * @link https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-6-KeyManager.md LSP6 KeyManager Standard.
@@ -620,6 +642,17 @@ export class ERC725<Schema extends GenericSchema> {
     });
 
     return result;
+  }
+
+  /**
+   * Decodes permissions from hexadecimal as defined by the LSP6 KeyManager Standard.
+   *
+   * @link https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-6-KeyManager.md LSP6 KeyManager Standard.
+   * @param permissionHex The permission hexadecimal value to be decoded.
+   * @returns Object specifying whether default LSP6 permissions are included in provided hexademical string.
+   */
+  decodePermissions(permissionHex: string) {
+    return ERC725.decodePermissions(permissionHex);
   }
 
   /**
@@ -670,6 +703,17 @@ export class ERC725<Schema extends GenericSchema> {
 
     // Array + Singleton
     return keccak256(keyName);
+  }
+
+  /**
+   * Hashes a key name for use on an ERC725Y contract according to LSP2 ERC725Y JSONSchema standard.
+   *
+   * @param keyName The key name you want to encode.
+   * @link https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md ERC725YJsonSchema standard.
+   * @returns {*} The keccak256 hash of the provided key name. This is the key that must be retrievable from the ERC725Y contract via ERC725Y.getData(bytes32 key).
+   */
+  encodeKeyName(keyName: string): string {
+    return ERC725.encodeKeyName(keyName);
   }
 }
 

--- a/src/types/Method.ts
+++ b/src/types/Method.ts
@@ -23,3 +23,16 @@ export interface MethodData {
   value: string;
   returnEncoding: Encoding;
 }
+
+export interface Permissions {
+  CHANGEOWNER?: boolean;
+  CHANGEPERMISSIONS?: boolean;
+  ADDPERMISSIONS?: boolean;
+  SETDATA?: boolean;
+  CALL?: boolean;
+  STATICCALL?: boolean;
+  DELEGATECALL?: boolean;
+  DEPLOY?: boolean;
+  TRANSFERVALUE?: boolean;
+  SIGN?: boolean;
+}


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
Improvement

Adds instance versions of `encodeKeyName` and `decodePermissions`, `encodePermissions`. Instance versions are available on an instance of ERC725 and call the static version directly.

Closes https://github.com/ERC725Alliance/erc725.js/issues/135