### PR TITLE
refactor: update LSP Schemas according to LSP2 changes

### DIFF
--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -54,18 +54,18 @@ const decodedDataOneKey = erc725.decodeData({
 const decodedDataManyKeys = erc725.decodeData({
   LSP3Profile:
     '0x6f357c6a820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361696670733a2f2f516d597231564a4c776572673670456f73636468564775676f3339706136727963455a4c6a7452504466573834554178',
-  'LSP3IssuedAssets[]': [
+  'LSP12IssuedAssets[]': [
     {
-      key: '0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0',
+      key: '0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd',
       value:
         '0x0000000000000000000000000000000000000000000000000000000000000002',
     },
     {
-      key: '0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000000',
+      key: '0x7c8c3416d6cda87cd42c71ea1843df2800000000000000000000000000000000',
       value: '0xd94353d9b005b3c0a9da169b768a31c57844e490',
     },
     {
-      key: '0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000001',
+      key: '0x7c8c3416d6cda87cd42c71ea1843df2800000000000000000000000000000001',
       value: '0xdaea594e385fc724449e3118b2db7e86dfba1826',
     },
   ],
@@ -77,7 +77,7 @@ const decodedDataManyKeys = erc725.decodeData({
     hashFunction: 'keccak256(utf8)',
     url: 'ipfs://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx',
   },
-  'LSP3IssuedAssets[]': [
+  'LSP12IssuedAssets[]': [
     '0xD94353D9B005B3c0A9Da169b768a31C57844e490',
     '0xDaea594E385Fc724449E3118B2Db7E86dFBa1826',
   ]
@@ -257,7 +257,7 @@ const encodedDataManyKeys = erc725.encodeData({
     hash: '0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361',
     url: 'ipfs://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx',
   },
-  'LSP3IssuedAssets[]': [
+  'LSP12IssuedAssets[]': [
     '0xD94353D9B005B3c0A9Da169b768a31C57844e490',
     '0xDaea594E385Fc724449E3118B2Db7E86dFBa1826',
   ],
@@ -267,9 +267,9 @@ const encodedDataManyKeys = erc725.encodeData({
 {
   keys: [
     '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
-    '0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0',
-    '0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000000',
-    '0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000001',
+    '0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd',
+    '0x7c8c3416d6cda87cd42c71ea1843df2800000000000000000000000000000000',
+    '0x7c8c3416d6cda87cd42c71ea1843df2800000000000000000000000000000001',
     '0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47',
   ],
   values: [
@@ -446,7 +446,7 @@ const dataAllKeys = await erc725.fetchData();
     }
   },
   LSP1UniversalReceiverDelegate: '0x50A02EF693fF6961A7F9178d1e53CC8BbE1DaD68',
-  'LSP3IssuedAssets[]': [
+  'LSP12IssuedAssets[]': [
     '0xc444009d38d3046bb0cF81Fa2Cd295ce46A67C78',
     '0x4fEbC3491230571F6e1829E46602e3b110215A2E',
     '0xB92a8DdA288638491AEE5C2a003D4CAbfa47aE3F',
@@ -557,7 +557,7 @@ const dataAllKeys = await erc725.getData();
     url: 'ipfs://QmbTmcbp8ZW23vkQrqkasMFqNg2z1iP4e3BCUMz9PKDsSV'
   },
   LSP1UniversalReceiverDelegate: '0x50A02EF693fF6961A7F9178d1e53CC8BbE1DaD68',
-  'LSP3IssuedAssets[]': [
+  'LSP12IssuedAssets[]': [
     '0xc444009d38d3046bb0cF81Fa2Cd295ce46A67C78',
     '0x4fEbC3491230571F6e1829E46602e3b110215A2E',
     '0xB92a8DdA288638491AEE5C2a003D4CAbfa47aE3F',
@@ -707,8 +707,8 @@ erc725.getSchema([
     valueType: 'bytes'
   },
   '0x3a47ab5bd3a594c3a8995f8fa58d087600000000000000000000000000000001': {
-    name: 'LSP3IssuedAssets[1]',
-    key: '0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0',
+    name: 'LSP12IssuedAssets[1]',
+    key: '0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd',
     keyType: 'Singleton',
     valueContent: 'Address',
     valueType: 'address'

--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -319,11 +319,11 @@ The hash must be retrievable from the ERC725Y contract via the [getData](#getdat
 ERC725.encodeKeyName('LSP3Profile');
 // '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5'
 ERC725.encodeKeyName('SupportedStandards:ERC725Account');
-// '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6'
+// '0xeafec4d89fa9619884b60000afdeb5d6e788fe0ba73c9eb2e30b8a4485e3a18f'
 ERC725.encodeKeyName(
   'AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe',
 );
-// '0x4b80742d0000000082ac0000cafecafecafecafecafecafecafecafecafecafe'
+// '0x4b80742de2bf82acb3630000cafecafecafecafecafecafecafecafecafecafe'
 
 // This method is also available on the instance:
 myErc725.encodeKeyName('LSP3Profile');

--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -319,7 +319,7 @@ The hash must be retrievable from the ERC725Y contract via the [getData](#getdat
 ERC725.encodeKeyName('LSP3Profile');
 // '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5'
 ERC725.encodeKeyName('SupportedStandards:ERC725Account');
-// '0xeafec4d89fa9619884b60000afdeb5d6e788fe0ba73c9eb2e30b8a4485e3a18f'
+// '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6'
 ERC725.encodeKeyName(
   'AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe',
 );

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,7 +30,7 @@ import Web3 from 'web3';
 const schemas = [
   {
     name: 'SupportedStandards:LSP3UniversalProfile',
-    key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
+    key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
     keyType: 'Mapping',
     valueContent: '0xabe425d6',
     valueType: 'bytes',

--- a/docs/writing-data.md
+++ b/docs/writing-data.md
@@ -48,8 +48,8 @@ export const schemas = [
     valueType: 'address',
   },
   {
-    name: 'LSP3IssuedAssets[]',
-    key: '0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0',
+    name: 'LSP12IssuedAssets[]',
+    key: '0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd',
     keyType: 'Array',
     valueContent: 'Address',
     valueType: 'address',
@@ -78,7 +78,7 @@ const encodedData = myERC725.encodeData({
     hash: '0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361',
     url: 'ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx',
   },
-  'LSP3IssuedAssets[]': [
+  'LSP12IssuedAssets[]': [
     '0xD94353D9B005B3c0A9Da169b768a31C57844e490',
     '0xDaea594E385Fc724449E3118B2Db7E86dFBa1826',
   ],

--- a/docs/writing-data.md
+++ b/docs/writing-data.md
@@ -28,7 +28,7 @@ import { ERC725 } from '@erc725/erc725.js';
 export const schemas = [
   {
     name: 'SupportedStandards:LSP3UniversalProfile',
-    key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
+    key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
     keyType: 'Mapping',
     valueContent: '0xabe425d6',
     valueType: 'bytes',

--- a/schemas/LSP10ReceivedVaults.json
+++ b/schemas/LSP10ReceivedVaults.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "LSP10VaultsMap:<address>",
+    "key": "0x192448c3c0f88c7f238c0000<address>",
+    "keyType": "Mapping",
+    "valueType": "bytes",
+    "valueContent": "Mixed"
+  },
+  {
+    "name": "LSP10Vaults[]",
+    "key": "0x55482936e01da86729a45d2b87a6b1d3bc582bea0ec00e38bdb340e3af6f9f06",
+    "keyType": "Array",
+    "valueType": "address",
+    "valueContent": "Address"
+  }
+]

--- a/schemas/LSP12IssuedAssets.json
+++ b/schemas/LSP12IssuedAssets.json
@@ -8,8 +8,8 @@
     },
     {
         "name": "LSP12IssuedAssetsMap:<address>",
-        "key": "0x74ac2555c10b934900000000<address>",
-        "keyType": "Bytes20Mapping",
+        "key": "0x74ac2555c10b9349e78f0000<address>",
+        "keyType": "Mapping",
         "valueType": "bytes",
         "valueContent": "Mixed"
     }

--- a/schemas/LSP3UniversalProfileMetadata.json
+++ b/schemas/LSP3UniversalProfileMetadata.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "SupportedStandards:LSP3UniversalProfile",
-    "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6",
+    "key": "0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38",
     "keyType": "Mapping",
     "valueType": "bytes4",
     "valueContent": "0xabe425d6"
@@ -22,14 +22,14 @@
   },
   {
     "name": "LSP12IssuedAssetsMap:<address>",
-    "key": "0x74ac2555c10b934900000000<address>",
-    "keyType": "Bytes20Mapping",
+    "key": "0x74ac2555c10b9349e78f0000<address>",
+    "keyType": "Mapping",
     "valueType": "bytes",
     "valueContent": "Mixed"
   },
   {
     "name": "LSP5ReceivedAssetsMap:<address>",
-    "key": "0x812c4334633eb81600000000<address>",
+    "key": "0x812c4334633eb816c80d0000<address>",
     "keyType": "Mapping",
     "valueType": "bytes",
     "valueContent": "Mixed"

--- a/schemas/LSP4DigitalAsset.json
+++ b/schemas/LSP4DigitalAsset.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "SupportedStandards:LSP4DigitalAsset",
-    "key": "0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624",
+    "key": "0xeafec4d89fa9619884b60000a4d96624a38f7ac2d8d9a604ecf07c12c77e480c",
     "keyType": "Mapping",
     "valueType": "bytes4",
     "valueContent": "0xa4d96624"
@@ -36,7 +36,7 @@
   },
   {
     "name": "LSP4CreatorsMap:<address>",
-    "key": "0x6de85eaf5d982b4e00000000<address>",
+    "key": "0x6de85eaf5d982b4e5da00000<address>",
     "keyType": "Mapping",
     "valueType": "bytes",
     "valueContent": "Mixed"

--- a/schemas/LSP5ReceivedAssets.json
+++ b/schemas/LSP5ReceivedAssets.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "LSP5ReceivedAssetsMap:<address>",
-    "key": "0x812c4334633eb81600000000<address>",
+    "key": "0x812c4334633eb816c80d0000<address>",
     "keyType": "Mapping",
     "valueType": "bytes",
     "valueContent": "Mixed"

--- a/schemas/LSP6KeyManager.json
+++ b/schemas/LSP6KeyManager.json
@@ -33,5 +33,12 @@
     "keyType": "MappingWithGrouping",
     "valueType": "bytes4[]",
     "valueContent": "Bytes4"
+  },
+  {
+    "name": "AddressPermissions:AllowedERC725YKeys:<address>",
+    "key": "0x4b80742de2bf90b8b4850000<address>",
+    "keyType": "MappingWithGrouping",
+    "valueType": "bytes4[]",
+    "valueContent": "Bytes4"
   }
 ]

--- a/schemas/LSP6KeyManager.json
+++ b/schemas/LSP6KeyManager.json
@@ -8,29 +8,29 @@
   },
   {
     "name": "AddressPermissions:Permissions:<address>",
-    "key": "0x4b80742d0000000082ac0000<address>",
-    "keyType": "Bytes20MappingWithGrouping",
+    "key": "0x4b80742de2bf82acb3630000<address>",
+    "keyType": "MappingWithGrouping",
     "valueType": "bytes32",
     "valueContent": "BitArray"
   },
   {
     "name": "AddressPermissions:AllowedAddresses:<address>",
-    "key": "0x4b80742d00000000c6dd0000<address>",
-    "keyType": "Bytes20MappingWithGrouping",
+    "key": "0x4b80742de2bfc6dd6b3c0000<address>",
+    "keyType": "MappingWithGrouping",
     "valueType": "address[]",
     "valueContent": "Address"
   },
   {
     "name": "AddressPermissions:AllowedFunctions:<address>",
-    "key": "0x4b80742d000000008efe0000<address>",
-    "keyType": "Bytes20MappingWithGrouping",
+    "key": "0x4b80742de2bf8efea1e80000<address>",
+    "keyType": "MappingWithGrouping",
     "valueType": "bytes4[]",
     "valueContent": "Bytes4"
   },
   {
     "name": "AddressPermissions:AllowedStandards:<address>",
-    "key": "0x4b80742d000000003efa0000<address>",
-    "keyType": "Bytes20MappingWithGrouping",
+    "key": "0x4b80742de2bf3efa94a30000<address>",
+    "keyType": "MappingWithGrouping",
     "valueType": "bytes4[]",
     "valueContent": "Bytes4"
   }

--- a/schemas/LSP9Vault.json
+++ b/schemas/LSP9Vault.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "SupportedStandards:LSP9Vault",
+    "key": "0xeafec4d89fa9619884b600007c0334a14085fefa8b51ae5a40895018882bdb90",
+    "keyType": "Mapping",
+    "valueType": "bytes4",
+    "valueContent": "0x7c0334a1"
+  }
+]


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
- Fixes in the ERC725Y JSON schemas (after the LSP2Change [here](https://github.com/lukso-network/LIPs/commit/2d2c727956ad1fe0bcbb496e6719a626925b116b))
- Add Few extra Schemas (LSP9,LSP10,LSP6)
- Documentation update (old keys)
### What is the current behaviour (you can also link to an open issue here)?
- Current behaviour is still according to the old version of LSP2.
### What is the new behaviour (if this is a feature change)?
- Change `Bytes20MappingWithGrouping` to `MappingWithGrouping`
- Change the constructing way of Mapping keys

## Others:
- [ ] Failing Tests should be fixed 