### PR TITLE
refactor!: remove old LSP2 Key Types (Bytes20..)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import Web3 from 'web3';
 const schema = [
   {
     name: 'SupportedStandards:LSP3UniversalProfile',
-    key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
+    key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
     keyType: 'Mapping',
     valueContent: '0xabe425d6',
     valueType: 'bytes',

--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -318,8 +318,8 @@ The hash must be retrievable from the ERC725Y contract via the [getData](#getdat
 ```javascript title="Encode the key name"
 ERC725.encodeKeyName('LSP3Profile');
 // '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5'
-ERC725.encodeKeyName('SupportedStandards:ERC725Account');
-// '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6'
+ERC725.encodeKeyName('SupportedStandards:LSP3UniversalProfile');
+// '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38'
 ERC725.encodeKeyName(
   'AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe',
 );

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -203,13 +203,6 @@ describe('Running @erc725/erc725.js tests...', () => {
         valueType: 'bytes',
       },
       {
-        name: 'SupportedStandards:ERC725Account',
-        key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6',
-        keyType: 'Singleton',
-        valueContent: '0xafdeb5d6',
-        valueType: 'bytes',
-      },
-      {
         name: 'LSP1UniversalReceiverDelegate',
         key: '0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47',
         keyType: 'Singleton',
@@ -224,7 +217,6 @@ describe('Running @erc725/erc725.js tests...', () => {
         hash: '0x70546a2accab18748420b63c63b5af4cf710848ae83afc0c51dd8ad17fb5e8b3',
         url: 'ipfs://QmecrGejUQVXpW4zS948pNvcnQrJ1KiAoM6bdfrVcWZsn5',
       },
-      'SupportedStandards:ERC725Account': '0xafdeb5d6',
       LSP1UniversalReceiverDelegate:
         '0x36e4Eb6Ee168EF54B1E8e850ACBE51045214B313',
     };

--- a/src/lib/encodeKeyName.test.ts
+++ b/src/lib/encodeKeyName.test.ts
@@ -15,29 +15,29 @@ describe('encodeKeyName', () => {
     },
     {
       keyName: 'SupportedStandards:LSP3UniversalProfile',
-      key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
+      key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
     },
     {
       keyName: 'MyCoolAddress:0xcafecafecafecafecafecafecafecafecafecafe',
-      key: '0x22496f48a493035f00000000cafecafecafecafecafecafecafecafecafecafe',
+      key: '0x22496f48a493035f0ab40000cafecafecafecafecafecafecafecafecafecafe',
     },
     {
       keyName: 'MyCoolAddress:cafecafecafecafecafecafecafecafecafecafe',
-      key: '0x22496f48a493035f00000000cafecafecafecafecafecafecafecafecafecafe',
+      key: '0x22496f48a493035f0ab40000cafecafecafecafecafecafecafecafecafecafe',
     },
     {
-      keyName: 'LSP3IssuedAssetsMap:b74a88C43BCf691bd7A851f6603cb1868f6fc147',
-      key: '0x83f5e77bfb14241600000000b74a88C43BCf691bd7A851f6603cb1868f6fc147',
+      keyName: 'LSP12IssuedAssetsMap:b74a88C43BCf691bd7A851f6603cb1868f6fc147',
+      key: '0x74ac2555c10b9349e78f0000b74a88C43BCf691bd7A851f6603cb1868f6fc147',
     },
     {
       keyName:
         'AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe',
-      key: '0x4b80742d0000000082ac0000cafecafecafecafecafecafecafecafecafecafe',
+      key: '0x4b80742de2bf82acb3630000cafecafecafecafecafecafecafecafecafecafe',
     },
     {
       keyName:
         'AddressPermissions:Permissions:0xcafecafecafecafecafecafecafecafecafecafe',
-      key: '0x4b80742d0000000082ac0000cafecafecafecafecafecafecafecafecafecafe',
+      key: '0x4b80742de2bf82acb3630000cafecafecafecafecafecafecafecafecafecafe',
     },
   ];
 

--- a/src/lib/schemaParser.test.ts
+++ b/src/lib/schemaParser.test.ts
@@ -69,19 +69,19 @@ describe('schemaParser getSchema', () => {
   describe('Mapping', () => {
     it('finds known mappings', () => {
       const schema = getSchema(
-        '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
+        '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
       );
 
       assert.deepStrictEqual(schema, {
         name: 'SupportedStandards:LSP3UniversalProfile',
-        key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
+        key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
         keyType: 'Mapping',
         valueContent: '0xabe425d6',
         valueType: 'bytes4',
       });
     });
 
-    it('finds unknown mappings', () => {
+    it.skip('finds unknown mappings', () => {
       // Key name: SupportedStandards:UnknownKey
       const schema = getSchema(
         '0xeafec4d89fa9619884b6b89135626455000000000000000000000000f4d7faed',
@@ -118,7 +118,7 @@ describe('schemaParser getSchema', () => {
   });
 
   describe('Bytes20MappingWithGrouping', () => {
-    it('finds Bytes20MappingWithGrouping', () => {
+    it.skip('finds Bytes20MappingWithGrouping', () => {
       const address = 'af3bf2ffb025098b79caddfbdd113b3681817744';
       const name = `AddressPermissions:Permissions:${address}`;
       const key = `0x4b80742d0000000082ac0000${address}`;

--- a/src/lib/schemaParser.test.ts
+++ b/src/lib/schemaParser.test.ts
@@ -81,24 +81,21 @@ describe('schemaParser getSchema', () => {
       });
     });
 
-    it.skip('finds unknown mappings', () => {
+    it('finds unknown mappings', () => {
       // Key name: SupportedStandards:UnknownKey
       const schema = getSchema(
-        '0xeafec4d89fa9619884b6b89135626455000000000000000000000000f4d7faed',
+        '0xeafec4d89fa9619884b60000f4d7faed14a1ab658d46d385bc29fb1eeaa56d0b',
       );
 
       assert.deepStrictEqual(schema, {
         name: 'SupportedStandards:??????',
-        key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000f4d7faed',
+        key: '0xeafec4d89fa9619884b60000f4d7faed14a1ab658d46d385bc29fb1eeaa56d0b',
         keyType: 'Mapping',
-        valueContent: '0xabe425d6',
+        valueContent: '?',
         valueType: 'bytes4',
       });
     });
-  });
-
-  describe('Bytes20Mapping', () => {
-    it('finds Bytes20Mapping', () => {
+    it('finds Known Mapping:<address> ', () => {
       const address = 'af3bf2ffb025098b79caddfbdd113b3681817744';
       const name = `MyCoolAddress:${address}`;
       const key = `0x22496f48a493035f00000000${address}`;
@@ -106,7 +103,7 @@ describe('schemaParser getSchema', () => {
       const extraSchema: ERC725JSONSchema = {
         name,
         key,
-        keyType: 'Bytes20Mapping',
+        keyType: 'Mapping',
         valueContent: 'Address',
         valueType: 'address',
       };
@@ -117,17 +114,17 @@ describe('schemaParser getSchema', () => {
     });
   });
 
-  describe('Bytes20MappingWithGrouping', () => {
-    it.skip('finds Bytes20MappingWithGrouping', () => {
+  describe('MappingWithGrouping', () => {
+    it('finds MappingWithGrouping', () => {
       const address = 'af3bf2ffb025098b79caddfbdd113b3681817744';
       const name = `AddressPermissions:Permissions:${address}`;
-      const key = `0x4b80742d0000000082ac0000${address}`;
+      const key = `0x4b80742de2bf82acb3630000${address}`;
       const schema = getSchema(key);
 
       assert.deepStrictEqual(schema, {
         name,
         key,
-        keyType: 'Bytes20MappingWithGrouping',
+        keyType: 'MappingWithGrouping',
         valueContent: 'BitArray',
         valueType: 'bytes32',
       });

--- a/src/lib/schemaParser.ts
+++ b/src/lib/schemaParser.ts
@@ -18,11 +18,8 @@ const getSchemasByKeyType = (
     Singleton: schemas.filter((schema) => schema.keyType === 'Singleton'),
     Array: schemas.filter((schema) => schema.keyType === 'Array'),
     Mapping: schemas.filter((schema) => schema.keyType === 'Mapping'),
-    Bytes20Mapping: schemas.filter(
-      (schema) => schema.keyType === 'Bytes20Mapping',
-    ),
-    Bytes20MappingWithGrouping: schemas.filter(
-      (schema) => schema.keyType === 'Bytes20MappingWithGrouping',
+    MappingWithGrouping: schemas.filter(
+      (schema) => schema.keyType === 'MappingWithGrouping',
     ),
   };
 };
@@ -88,46 +85,22 @@ const findMappingSchemaForKey = (
   // 2. "Semi defined mappings" i.e. "SupportedStandards:??????"
   keySchema =
     schemas.find(
-      (schema) => schema.key.substring(0, 58) === key.substring(0, 58),
+      (schema) => `${schema.key.substring(0, 22)}0000` === key.substring(0, 26),
     ) || null;
 
   if (!keySchema) {
     return null;
   }
-
+  // TODO: Handle the SupportedStandard Keys; we can get the valueContent from the Keys
   return {
     ...keySchema,
+    valueContent: '?',
     name: `${keySchema.name.split(':')[0]}:??????`,
     key,
   };
 };
 
-const findBytes20MappingSchemaForKey = (
-  key: string,
-  schemas: ERC725JSONSchema[],
-): ERC725JSONSchema | null => {
-  const keySchema =
-    schemas.find(
-      (schema) => schema.key.substring(0, 26) === key.substring(0, 26),
-    ) || null;
-
-  const address = key.substring(26);
-
-  if (keySchema) {
-    return {
-      ...keySchema,
-      key,
-      name: `${keySchema.name.substring(
-        0,
-        keySchema.name.lastIndexOf(':'),
-      )}:${address}`,
-    };
-  }
-
-  return null;
-};
-
-const findBytes20MappingWithGroupingSchemaForKey = (
+const findMappingWithGroupingSchemaForKey = (
   key: string,
   schemas: ERC725JSONSchema[],
 ): ERC725JSONSchema | null => {
@@ -178,18 +151,9 @@ function schemaParser(
     return foundSchema;
   }
 
-  foundSchema = findBytes20MappingSchemaForKey(
+  foundSchema = findMappingWithGroupingSchemaForKey(
     key,
-    schemasByKeyType.Bytes20Mapping,
-  );
-
-  if (foundSchema) {
-    return foundSchema;
-  }
-
-  foundSchema = findBytes20MappingWithGroupingSchemaForKey(
-    key,
-    schemasByKeyType.Bytes20MappingWithGrouping,
+    schemasByKeyType.MappingWithGrouping,
   );
 
   return foundSchema;

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -514,20 +514,20 @@ describe('utils', () => {
         keyName: 'SupportedStandards:LSP3UniversalProfile',
       },
       {
-        keyType: 'Bytes20Mapping',
+        keyType: 'Mapping',
         keyName: 'MyCoolAddress:0xcafecafecafecafecafecafecafecafecafecafe',
       },
       {
-        keyType: 'Bytes20Mapping',
+        keyType: 'Mapping',
         keyName: 'MyCoolAddress:cafecafecafecafecafecafecafecafecafecafe',
       },
       {
-        keyType: 'Bytes20MappingWithGrouping',
+        keyType: 'MappingWithGrouping',
         keyName:
           'AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe',
       },
       {
-        keyType: 'Bytes20MappingWithGrouping',
+        keyType: 'MappingWithGrouping',
         keyName:
           'AddressPermissions:Permissions:0xcafecafecafecafecafecafecafecafecafecafe',
       },

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -144,14 +144,10 @@ export function guessKeyTypeFromKeyName(
   const splittedKeyName = keyName.split(':');
 
   if (splittedKeyName.length === 3) {
-    return 'Bytes20MappingWithGrouping';
+    return 'MappingWithGrouping';
   }
 
   if (splittedKeyName.length === 2) {
-    if (isAddress(splittedKeyName[1])) {
-      return 'Bytes20Mapping';
-    }
-
     return 'Mapping';
   }
 
@@ -250,8 +246,7 @@ export function encodeKey(
 
       return results;
     }
-    case 'bytes20mapping':
-    case 'bytes20mappingwithgrouping':
+    case 'mappingwithgrouping':
     case 'singleton':
     case 'mapping':
       return encodeKeyValue(
@@ -387,8 +382,7 @@ export function decodeKey(schema: ERC725JSONSchema, value) {
 
       return results;
     }
-    case 'bytes20mapping':
-    case 'bytes20mappingwithgrouping':
+    case 'mappingwithgrouping':
     case 'singleton':
     case 'mapping': {
       if (Array.isArray(value)) {

--- a/src/types/ERC725JSONSchema.ts
+++ b/src/types/ERC725JSONSchema.ts
@@ -4,8 +4,8 @@ export type ERC725JSONSchemaKeyType =
   | 'Singleton'
   | 'Mapping'
   | 'Array'
-  | 'Bytes20Mapping'
-  | 'Bytes20MappingWithGrouping';
+  | 'Mapping'
+  | 'MappingWithGrouping';
 
 export type ERC725JSONSchemaValueContent =
   | 'Number'

--- a/test/mockSchema.ts
+++ b/test/mockSchema.ts
@@ -19,7 +19,7 @@ export const mockSchema: (ERC725JSONSchema & {
   // Case 1
   {
     name: 'SupportedStandards:LSP3UniversalProfile',
-    key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
+    key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
     keyType: 'Mapping',
     valueContent: '0xabe425d6',
     valueType: 'bytes',
@@ -576,8 +576,8 @@ export const mockSchema: (ERC725JSONSchema & {
 
   {
     name: 'MyCoolAddress:0xcafecafecafecafecafecafecafecafecafecafe',
-    key: '0x22496f48a493035f00000000cafecafecafecafecafecafecafecafecafecafe',
-    keyType: 'Bytes20Mapping',
+    key: '0x22496f48a493035f0ab40000cafecafecafecafecafecafecafecafecafecafe',
+    keyType: 'Mapping',
     valueContent: '0xabe425d6',
     valueType: 'bytes',
     // Testing data
@@ -588,8 +588,8 @@ export const mockSchema: (ERC725JSONSchema & {
   },
   {
     name: 'AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe',
-    key: '0x4b80742d0000000082ac0000cafecafecafecafecafecafecafecafecafecafe',
-    keyType: 'Bytes20MappingWithGrouping',
+    key: '0x4b80742de2bf82acb3630000cafecafecafecafecafecafecafecafecafecafe',
+    keyType: 'MappingWithGrouping',
     valueContent: '0xabe425d6',
     valueType: 'bytes',
     // Testing data


### PR DESCRIPTION
## What does this PR introduce? 
- Include the changes from #162 
- refactor!: remove old LSP2 Key Types (Bytes20..)
- fix failing tests
Closes #165 
Closes #163 
