### PR TITLE
feat: add dynamic keys support for `encodeData`

### DIFF
--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -181,6 +181,11 @@ When encoding JSON, it is possible to pass in the JSON object and the URL where 
 
 The key can be either the named key (i.e. `LSP3Profile`) or the hashed key (with or without `0x` prefix, i.e. `0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5` or `5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5`).
 
+The key also supports dynamic keys for [`Mapping`](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#mapping) and [`MappingWithGrouping`](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#mapping). Therefore, you can use variables in the key name such as `LSP12IssuedAssetsMap:<address>`. In that case, the value should be an object with two keys:
+
+- `dynamicKeyParts`: string or string[&nbsp;] which holds the variables that needs to be encoded.
+- `value`: the value that needs to be encoded. Same as for non dynamic keys.
+
 #### Returns
 
 | Name          | Type   | Description                                                                                                                                                                                                |
@@ -191,8 +196,8 @@ After the `data` is encoded, the object is ready to be stored in smart contracts
 
 #### Examples
 
-```javascript title="Encode a JSONURL with json and uploaded URL"
-const encodedDataOneKey = erc725.encodeData({
+```javascript title="Encode a JSONURL with JSON and uploaded URL"
+erc725.encodeData({
   LSP3Profile: {
     json: profileJson,
     url: 'ipfs://QmQTqheBLZFnQUxu5RDs8tA9JtkxfZqMBcmGd9sukXxwRm',
@@ -234,8 +239,8 @@ erc725.encodeData({
 */
 ```
 
-```javascript title="Encode a JSONURL with json, hash function, hash and uploaded URL"
-const encodedDataOneKeyV2 = erc725.encodeData({
+```javascript title="Encode a JSONURL with hash function, hash and uploaded URL"
+erc725.encodeData({
   LSP3Profile: {
     hashFunction: 'keccak256(utf8)',
     hash: '0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361',
@@ -250,8 +255,58 @@ const encodedDataOneKeyV2 = erc725.encodeData({
 */
 ```
 
+```javascript title="Encode dynamic keys"
+erc725.encodeData(
+  {
+    'DynamicKey:<address>': {
+      dynamicKeyParts: ['0xbedbedbedbedbedbedbedbedbedbedbedbedbedb'],
+      value: '0xcafecafecafecafecafecafecafecafecafecafe',
+    },
+  },
+  [
+    {
+      name: 'DynamicKey:<address>',
+      key: '0x0fb367364e1852abc5f20000<address>',
+      keyType: 'Mapping',
+      valueType: 'bytes',
+      valueContent: 'Address',
+    },
+  ],
+);
+/**
+{
+  keys: ['0x0fb367364e1852abc5f20000bedbedbedbedbedbedbedbedbedbedbedbedbedb'],
+  values: ['0xcafecafecafecafecafecafecafecafecafecafe]
+}
+*/
+
+erc725.encodeData(
+  {
+    'DynamicKey:<bytes4>:<string>': {
+      dynamicKeyParts: ['0x11223344', 'Summer'],
+      value: '0xcafecafecafecafecafecafecafecafecafecafe',
+    },
+  },
+  [
+    {
+      name: 'DynamicKey:<bytes4>:<string>',
+      key: '0xForDynamicKeysThisFieldIsIrrelevantAndWillBeOverwriten',
+      keyType: 'Mapping',
+      valueType: 'bytes',
+      valueContent: 'Address',
+    },
+  ],
+);
+/**
+{
+  keys: ['0x0fb367364e1852abc5f2000078c964cd805233eb39f2db152340079088809725'],
+  values: ['0xcafecafecafecafecafecafecafecafecafecafe']
+}
+*/
+```
+
 ```javascript title="Encode multiple keys at once"
-const encodedDataManyKeys = erc725.encodeData({
+erc725.encodeData({
   LSP3Profile: {
     hashFunction: 'keccak256(utf8)',
     hash: '0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361',

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,6 @@ import { EthereumProviderWrapper } from './providers/ethereumProviderWrapper';
 
 import {
   encodeArrayKey,
-  getSchemaElement,
   decodeData,
   decodeKeyValue,
   decodeKey,
@@ -54,6 +53,7 @@ import {
   ERC725JSONSchemaValueContent,
   ERC725JSONSchemaValueType,
 } from './types/ERC725JSONSchema';
+import { getSchemaElement } from './lib/getSchemaElement';
 
 export {
   ERC725JSONSchema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,16 +121,28 @@ export class ERC725 {
   // eslint-disable-next-line class-methods-use-this
   private validateSchemas(schemas: ERC725JSONSchema[]) {
     return schemas.filter((schema) => {
-      const encodedKeyName = encodeKeyName(schema.name);
-      const isKeyValid = schema.key === encodedKeyName;
+      try {
+        const encodedKeyName = encodeKeyName(schema.name);
 
-      if (!isKeyValid) {
-        console.log(
-          `The schema with keyName: ${schema.key} is skipped because its key hash does not match its key name (expected: ${encodedKeyName}, got: ${schema.key}).`,
-        );
+        const isKeyValid = schema.key === encodedKeyName;
+
+        if (!isKeyValid) {
+          console.log(
+            `The schema with keyName: ${schema.key} is skipped because its key hash does not match its key name (expected: ${encodedKeyName}, got: ${schema.key}).`,
+          );
+        }
+
+        return isKeyValid;
+      } catch (err: any) {
+        // We could not encodeKeyName, probably because the key is dynamic (Mapping or MappingWithGrouping).
+
+        // TODO: make sure the dynamic key name is valid:
+        // - has max 2 variables
+        // - variables are correct (<string>, <bool>, etc.)
+
+        // Keeping dynamic keys may be an issue for getData / fetchData functions.
+        return true;
       }
-
-      return isKeyValid;
     });
   }
 

--- a/src/lib/encodeKeyName.test.ts
+++ b/src/lib/encodeKeyName.test.ts
@@ -4,6 +4,7 @@ import { keccak256 } from 'web3-utils';
 import {
   encodeDynamicKeyPart,
   encodeKeyName,
+  generateDynamicKeyName,
   isDynamicKeyName,
 } from './encodeKeyName';
 
@@ -341,6 +342,53 @@ describe('encodeDynamicKeyPart', () => {
   it('throws if <bytesM> is called with wrong number of bytes', () => {
     assert.throws(() =>
       encodeDynamicKeyPart('<bytes8>', '0xd1b2917d26eeeaad1234', 20),
+    );
+  });
+});
+
+describe('generateDynamicKeyName', () => {
+  const testCases = [
+    {
+      keyName: 'MyKey:<string>',
+      dynamicKeyParts: 'HelloHowAreYou',
+      expectedKeyName: 'MyKey:HelloHowAreYou',
+    },
+    {
+      keyName: 'MyKey:Grouping:<string>',
+      dynamicKeyParts: 'HelloHowAreYou',
+      expectedKeyName: 'MyKey:Grouping:HelloHowAreYou',
+    },
+
+    {
+      keyName: 'MyKey:<bytes4>:<address>',
+      dynamicKeyParts: [
+        '0x11223344',
+        '0x2ab3903c6e5815f4bc2a95b7f3b22b6a289bacac',
+      ],
+      expectedKeyName:
+        'MyKey:11223344:2ab3903c6e5815f4bc2a95b7f3b22b6a289bacac',
+    },
+    {
+      keyName: 'Addresses:<address>',
+      dynamicKeyParts: [
+        '2ab3903c6e5815f4bc2a95b7f3b22b6a289bacac', // without 0x in the address
+      ],
+      expectedKeyName: 'Addresses:2ab3903c6e5815f4bc2a95b7f3b22b6a289bacac',
+    },
+  ];
+
+  testCases.forEach((testCase) => {
+    it(`generates key name: ${testCase.keyName} correctly`, () => {
+      assert.deepStrictEqual(
+        generateDynamicKeyName(testCase.keyName, testCase.dynamicKeyParts),
+        testCase.expectedKeyName,
+      );
+    });
+  });
+
+  it('throws if encoding with wrong number of dynamic values', () => {
+    assert.throws(() =>
+      generateDynamicKeyName('Addresses:<bytes4>:<address>', '0x11223344'),
     );
   });
 });

--- a/src/lib/getSchemaElement.test.ts
+++ b/src/lib/getSchemaElement.test.ts
@@ -1,0 +1,65 @@
+import assert from 'assert';
+
+import { ERC725JSONSchema } from '../types/ERC725JSONSchema';
+import { getSchemaElement } from './getSchemaElement';
+
+describe('getSchemaElement', () => {
+  it('gets the schemaElement from key name and key hash (with and without 0x prefix) correctly', () => {
+    const schemas: ERC725JSONSchema[] = [
+      {
+        name: 'LSP3Profile',
+        key: '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
+        keyType: 'Singleton',
+        valueContent: 'JSONURL',
+        valueType: 'bytes',
+      },
+    ];
+
+    assert.strictEqual(getSchemaElement(schemas, schemas[0].name), schemas[0]);
+    assert.strictEqual(getSchemaElement(schemas, schemas[0].key), schemas[0]);
+    assert.strictEqual(
+      getSchemaElement(schemas, schemas[0].key.slice(2)),
+      schemas[0],
+    );
+  });
+
+  const schemasWithDynamicKey: ERC725JSONSchema[] = [
+    {
+      name: 'LSP12IssuedAssetsMap:<address>',
+      key: '0x74ac2555c10b9349e78f0000<address>',
+      keyType: 'Mapping',
+      valueType: 'bytes',
+      valueContent: 'Mixed',
+    },
+    {
+      name: 'ARandomKey',
+      key: '0x7cf0c8053453d0353fdbad6a48e68966b35dd13cb3a62e7b75009dc5035b80c0',
+      keyType: 'Singleton',
+      valueContent: 'JSONURL',
+      valueType: 'bytes',
+    },
+  ];
+
+  it('throws is attempt to get a dynamic key without dynamicKeyParts', () => {
+    assert.throws(() =>
+      getSchemaElement(schemasWithDynamicKey, 'LSP12IssuedAssetsMap:<address>'),
+    );
+  });
+
+  it('gets the schemeElement for a dynamic key correctly', () => {
+    assert.deepStrictEqual(
+      getSchemaElement(
+        schemasWithDynamicKey,
+        'LSP12IssuedAssetsMap:<address>',
+        ['0x2ab3903c6e5815f4bc2a95b7f3b22b6a289bacac'],
+      ),
+      {
+        name: 'LSP12IssuedAssetsMap:2ab3903c6e5815f4bc2a95b7f3b22b6a289bacac',
+        key: '0x74ac2555c10b9349e78f00002ab3903c6e5815f4bc2a95b7f3b22b6a289bacac',
+        keyType: 'Mapping',
+        valueType: 'bytes',
+        valueContent: 'Mixed',
+      },
+    );
+  });
+});

--- a/src/lib/getSchemaElement.ts
+++ b/src/lib/getSchemaElement.ts
@@ -1,0 +1,89 @@
+import { isHex, isHexStrict } from 'web3-utils';
+import { DynamicKeyParts } from '../types/dynamicKeys';
+import { ERC725JSONSchema } from '../types/ERC725JSONSchema';
+import {
+  encodeKeyName,
+  generateDynamicKeyName,
+  isDynamicKeyName,
+} from './encodeKeyName';
+
+/**
+ *
+ * @param schemas
+ * @param namedDynamicKey
+ * @param dynamicKeyParts
+ * @returns
+ */
+const getSchemaElementForDynamicKeyName = (
+  schemas: ERC725JSONSchema[],
+  namedDynamicKey: string,
+  dynamicKeyParts: DynamicKeyParts,
+): ERC725JSONSchema => {
+  // In that case, we will generate a new schema element with the final computed name and encoded key hash.
+
+  const schemaElement = schemas.find((e) => e.name === namedDynamicKey);
+
+  if (!schemaElement) {
+    throw new Error(
+      `No matching schema found for dynamic key: ${namedDynamicKey}`,
+    );
+  }
+
+  // once we have the schemaElement with dynamic parts, we need to replace the name and the key:
+
+  const key = encodeKeyName(namedDynamicKey, dynamicKeyParts);
+  const name = generateDynamicKeyName(namedDynamicKey, dynamicKeyParts);
+
+  return {
+    ...schemaElement,
+    key,
+    name,
+  };
+};
+
+/**
+ *
+ * @param schemas An array of ERC725JSONSchema objects.
+ * @param {string} namedOrHashedKey A string of either the schema element name, or hashed key (with or without the 0x prefix).
+ * @param dynamicKeyParts if a dynamic named key is given, you should also set the dynamicKeyParts.
+ *
+ * @return The requested schema element from the full array of schemas.
+ */
+export function getSchemaElement(
+  schemas: ERC725JSONSchema[],
+  namedOrHashedKey: string,
+  dynamicKeyParts?: DynamicKeyParts,
+): ERC725JSONSchema {
+  let keyHash: string;
+
+  if (isDynamicKeyName(namedOrHashedKey)) {
+    if (!dynamicKeyParts) {
+      throw new Error(
+        `Can't getSchemaElement for dynamic key: ${namedOrHashedKey} without dynamicKeyParts.`,
+      );
+    }
+    return getSchemaElementForDynamicKeyName(
+      schemas,
+      namedOrHashedKey,
+      dynamicKeyParts,
+    );
+  }
+
+  if (isHex(namedOrHashedKey)) {
+    keyHash = isHexStrict(namedOrHashedKey)
+      ? namedOrHashedKey
+      : `0x${namedOrHashedKey}`;
+  } else {
+    keyHash = encodeKeyName(namedOrHashedKey);
+  }
+
+  const schemaElement = schemas.find((e) => e.key === keyHash);
+
+  if (!schemaElement) {
+    throw new Error(
+      `No matching schema found for key: ${namedOrHashedKey} (${keyHash}).`,
+    );
+  }
+
+  return schemaElement;
+}

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -11,7 +11,6 @@ import {
   flattenEncodedData,
   guessKeyTypeFromKeyName,
   isDataAuthentic,
-  getSchemaElement,
   encodeArrayKey,
   encodeKeyValue,
   decodeKeyValue,
@@ -494,73 +493,6 @@ describe('utils', () => {
           '0x5bed9e061cea8b4be17d3b5ea85de62f483a40fd',
         ],
       });
-    });
-  });
-
-  describe('getSchemaElement', () => {
-    it('gets the schemaElement from key name and key hash (with and without 0x prefix) correctly', () => {
-      const schemas: ERC725JSONSchema[] = [
-        {
-          name: 'LSP3Profile',
-          key: '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
-          keyType: 'Singleton',
-          valueContent: 'JSONURL',
-          valueType: 'bytes',
-        },
-      ];
-
-      assert.strictEqual(
-        getSchemaElement(schemas, schemas[0].name),
-        schemas[0],
-      );
-      assert.strictEqual(getSchemaElement(schemas, schemas[0].key), schemas[0]);
-      assert.strictEqual(
-        getSchemaElement(schemas, schemas[0].key.slice(2)),
-        schemas[0],
-      );
-    });
-
-    const schemasWithDynamicKey: ERC725JSONSchema[] = [
-      {
-        name: 'LSP12IssuedAssetsMap:<address>',
-        key: '0x74ac2555c10b9349e78f0000<address>',
-        keyType: 'Mapping',
-        valueType: 'bytes',
-        valueContent: 'Mixed',
-      },
-      {
-        name: 'ARandomKey',
-        key: '0x7cf0c8053453d0353fdbad6a48e68966b35dd13cb3a62e7b75009dc5035b80c0',
-        keyType: 'Singleton',
-        valueContent: 'JSONURL',
-        valueType: 'bytes',
-      },
-    ];
-
-    it('throws is attempt to get a dynamic key without dynamicKeyParts', () => {
-      assert.throws(() =>
-        getSchemaElement(
-          schemasWithDynamicKey,
-          'LSP12IssuedAssetsMap:<address>',
-        ),
-      );
-    });
-
-    it('gets the schemeElement for a dynamic key correctly', () => {
-      assert.deepStrictEqual(
-        getSchemaElement(
-          schemasWithDynamicKey,
-          'LSP12IssuedAssetsMap:<address>',
-          ['0x2ab3903c6e5815f4bc2a95b7f3b22b6a289bacac'],
-        ),
-        {
-          name: 'LSP12IssuedAssetsMap:2ab3903c6e5815f4bc2a95b7f3b22b6a289bacac',
-          key: '0x74ac2555c10b9349e78f00002ab3903c6e5815f4bc2a95b7f3b22b6a289bacac',
-          keyType: 'Mapping',
-          valueType: 'bytes',
-          valueContent: 'Mixed',
-        },
-      );
     });
   });
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,8 +20,6 @@
 import {
   checkAddressChecksum,
   isAddress,
-  isHex,
-  isHexStrict,
   numberToHex,
   padLeft,
 } from 'web3-utils';
@@ -52,12 +50,9 @@ import {
   valueContentEncodingMap as valueContentMap,
 } from './encoder';
 import { AssetURLEncode } from '../types/encodeData';
-import {
-  encodeKeyName,
-  generateDynamicKeyName,
-  isDynamicKeyName,
-} from './encodeKeyName';
-import { DynamicKeyPartInput, DynamicKeyParts } from '../types/dynamicKeys';
+import { isDynamicKeyName } from './encodeKeyName';
+import { DynamicKeyPartInput } from '../types/dynamicKeys';
+import { getSchemaElement } from './getSchemaElement';
 
 /**
  *
@@ -161,87 +156,6 @@ export function guessKeyTypeFromKeyName(
   }
 
   return 'Singleton';
-}
-
-/**
- *
- * @param schemas
- * @param namedDynamicKey
- * @param dynamicKeyParts
- * @returns
- */
-const getSchemaElementForDynamicKeyName = (
-  schemas: ERC725JSONSchema[],
-  namedDynamicKey: string,
-  dynamicKeyParts: DynamicKeyParts,
-): ERC725JSONSchema => {
-  // In that case, we will generate a new schema element with the final computed name and encoded key hash.
-
-  const schemaElement = schemas.find((e) => e.name === namedDynamicKey);
-
-  if (!schemaElement) {
-    throw new Error(
-      `No matching schema found for dynamic key: ${namedDynamicKey}`,
-    );
-  }
-
-  // once we have the schemaElement with dynamic parts, we need to replace the name and the key:
-
-  const key = encodeKeyName(namedDynamicKey, dynamicKeyParts);
-  const name = generateDynamicKeyName(namedDynamicKey, dynamicKeyParts);
-
-  return {
-    ...schemaElement,
-    key,
-    name,
-  };
-};
-
-/**
- *
- * @param schemas An array of ERC725JSONSchema objects.
- * @param {string} namedOrHashedKey A string of either the schema element name, or hashed key (with or without the 0x prefix).
- * @param dynamicKeyParts if a dynamic named key is given, you should also set the dynamicKeyParts.
- *
- * @return The requested schema element from the full array of schemas.
- */
-export function getSchemaElement(
-  schemas: ERC725JSONSchema[],
-  namedOrHashedKey: string,
-  dynamicKeyParts?: DynamicKeyParts,
-): ERC725JSONSchema {
-  let keyHash: string;
-
-  if (isDynamicKeyName(namedOrHashedKey)) {
-    if (!dynamicKeyParts) {
-      throw new Error(
-        `Can't getSchemaElement for dynamic key: ${namedOrHashedKey} without dynamicKeyParts.`,
-      );
-    }
-    return getSchemaElementForDynamicKeyName(
-      schemas,
-      namedOrHashedKey,
-      dynamicKeyParts,
-    );
-  }
-
-  if (isHex(namedOrHashedKey)) {
-    keyHash = isHexStrict(namedOrHashedKey)
-      ? namedOrHashedKey
-      : `0x${namedOrHashedKey}`;
-  } else {
-    keyHash = encodeKeyName(namedOrHashedKey);
-  }
-
-  const schemaElement = schemas.find((e) => e.key === keyHash);
-
-  if (!schemaElement) {
-    throw new Error(
-      `No matching schema found for key: ${namedOrHashedKey} (${keyHash}).`,
-    );
-  }
-
-  return schemaElement;
 }
 
 /**

--- a/src/types/dynamicKeys.ts
+++ b/src/types/dynamicKeys.ts
@@ -1,0 +1,10 @@
+// Put types / interfaces related to dynamic keys here
+
+import { EncodeDataType } from './encodeData/JSONURL';
+
+export type DynamicKeyParts = string | string[];
+
+export interface DynamicKeyPartInput {
+  dynamicKeyParts: DynamicKeyParts;
+  value: EncodeDataType;
+}

--- a/src/types/encodeData/JSONURL.ts
+++ b/src/types/encodeData/JSONURL.ts
@@ -1,4 +1,5 @@
 import { SUPPORTED_HASH_FUNCTIONS } from '../../lib/constants';
+import { DynamicKeyPartInput } from '../dynamicKeys';
 
 export interface KeyValuePair {
   key: string;
@@ -23,9 +24,11 @@ export interface URLDataWithJson extends URLData {
 
 export type JSONURLDataToEncode = URLDataWithHash | URLDataWithJson;
 
+export type EncodeDataType = string | string[] | JSONURLDataToEncode;
+
 export type EncodeDataInput = Record<
   string,
-  string | string[] | JSONURLDataToEncode
+  EncodeDataType | DynamicKeyPartInput
 >;
 
 export interface EncodeDataReturn {


### PR DESCRIPTION
Related to #137 

Allowing the import of dynamic keys on class instantiation might break the `fetchData`/`getData` features.

## Docs

![image](https://user-images.githubusercontent.com/477945/171875107-296b2501-fb32-4047-b998-2fee2d8e3d5d.png)

![image](https://user-images.githubusercontent.com/477945/171875166-99a88203-edec-49e9-bef1-0a9c0ac833cf.png)

## Local test

![image](https://user-images.githubusercontent.com/477945/171875272-c8b92c52-c5d0-4994-a4f8-02a02aa8f0cb.png)
