### PR TITLE
Suggest different version naming for ERC725Y interface IDs in `constants.js`

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -42,7 +42,7 @@ import {
 import 'isomorphic-fetch';
 
 import {
-  INTERFACE_IDS,
+  ERC725Y_INTERFACE_IDS,
   SUPPORTED_HASH_FUNCTION_STRINGS,
 } from './lib/constants';
 import { decodeKey } from './lib/decodeData';
@@ -275,7 +275,7 @@ describe('Running @erc725/erc725.js tests...', () => {
             },
           ],
         },
-        [INTERFACE_IDS.ERC725Y_LEGACY],
+        [ERC725Y_INTERFACE_IDS.legacy],
       );
       const erc725 = new ERC725(
         [
@@ -321,7 +321,7 @@ describe('Running @erc725/erc725.js tests...', () => {
             },
           ],
         },
-        [INTERFACE_IDS.ERC725Y],
+        [ERC725Y_INTERFACE_IDS['3.0']],
       );
       const erc725 = new ERC725(
         [
@@ -380,15 +380,15 @@ describe('Running @erc725/erc725.js tests...', () => {
   });
 
   [
-    { name: 'legacy', interface: INTERFACE_IDS.ERC725Y_LEGACY },
-    { name: 'latest', interface: INTERFACE_IDS.ERC725Y },
+    { name: 'legacy', interface: ERC725Y_INTERFACE_IDS.legacy },
+    { name: 'latest', interface: ERC725Y_INTERFACE_IDS['3.0'] },
   ].forEach((contractVersion) => {
     describe(`Getting all data in schema by provider [ERC725Y ${contractVersion.name}][mock]`, () => {
       // Construct the full data and results
       const fullResults = generateAllResults(mockSchema);
       const allRawData = generateAllRawData(
         mockSchema,
-        contractVersion.interface === INTERFACE_IDS.ERC725Y,
+        contractVersion.interface === ERC725Y_INTERFACE_IDS['3.0'],
       );
 
       it('with web3.currentProvider', async () => {
@@ -482,7 +482,7 @@ describe('Running @erc725/erc725.js tests...', () => {
         );
       });
 
-      if (contractVersion.interface === INTERFACE_IDS.ERC725Y) {
+      if (contractVersion.interface === ERC725Y_INTERFACE_IDS['3.0']) {
         it('fetchData JSONURL with dynamic key', async () => {
           const provider = new HttpProvider(
             {
@@ -529,7 +529,7 @@ describe('Running @erc725/erc725.js tests...', () => {
         });
       }
 
-      if (contractVersion.interface === INTERFACE_IDS.ERC725Y_LEGACY) {
+      if (contractVersion.interface === ERC725Y_INTERFACE_IDS.legacy) {
         it('fetchData AssetURL', async () => {
           const fetchStub = sinon.stub(global, 'fetch');
           fetchStub
@@ -587,7 +587,7 @@ describe('Running @erc725/erc725.js tests...', () => {
       it(schemaElement.name + ' with web3.currentProvider', async () => {
         const returnRawData = generateAllRawData([schemaElement], false);
         const provider = new HttpProvider({ returnData: returnRawData }, [
-          INTERFACE_IDS.ERC725Y_LEGACY,
+          ERC725Y_INTERFACE_IDS.legacy,
         ]);
         const erc725 = new ERC725(mockSchema, address, provider);
         const result = await erc725.getData(
@@ -608,7 +608,7 @@ describe('Running @erc725/erc725.js tests...', () => {
       it(schemaElement.name + ' with ethereumProvider EIP 1193', async () => {
         const returnRawData = generateAllRawData([schemaElement], false);
         const provider = new HttpProvider({ returnData: returnRawData }, [
-          INTERFACE_IDS.ERC725Y_LEGACY,
+          ERC725Y_INTERFACE_IDS.legacy,
         ]);
         const erc725 = new ERC725(mockSchema, address, provider);
         const result = await erc725.getData(

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,10 +4,22 @@ import { numberToHex, keccak256 } from 'web3-utils';
 import { MethodData, Encoding, Method } from '../types/Method';
 
 // https://github.com/ERC725Alliance/ERC725/blob/develop/docs/ERC-725.md#specification
-export const INTERFACE_IDS = {
-  ERC725Y_LEGACY: '0x2bd57b73',
-  ERC725Y_v200: '0x5a988c0f', // introduced in v0.2.0
-  ERC725Y: '0x714df77c', // introduced in v0.6.0
+export const ERC725Y_INTERFACE_IDS = {
+  // interface functions:
+  //     - getData(bytes32)
+  //     - setData(bytes32,bytes)
+  legacy: '0x2bd57b73',
+  // interface functions:
+  //     - getData(bytes32[])
+  //     - setData(bytes32[],bytes[])
+  '2.0': '0x5a988c0f',
+  // version 3.0.0 introduced function overloading
+  // interface functions:
+  //     - getData(bytes32)
+  //     - setData(bytes32,bytes)
+  //     - getData(bytes32[])
+  //     - setData(bytes32[],bytes[])
+  '3.0': '0x714df77c',
 };
 
 export enum ERC725_VERSION {

--- a/src/providers/ethereumProviderWrapper.ts
+++ b/src/providers/ethereumProviderWrapper.ts
@@ -24,7 +24,11 @@
 
 import * as abi from 'web3-eth-abi';
 
-import { ERC725_VERSION, INTERFACE_IDS, METHODS } from '../lib/constants';
+import {
+  ERC725_VERSION,
+  ERC725Y_INTERFACE_IDS,
+  METHODS,
+} from '../lib/constants';
 import { decodeResult as decodeResultUtils } from '../lib/provider-wrapper-utils';
 import { JsonRpcEthereumProvider } from '../types/JsonRpc';
 import { Method } from '../types/Method';
@@ -61,7 +65,7 @@ export class EthereumProviderWrapper {
   async getErc725YVersion(address: string): Promise<ERC725_VERSION> {
     const isErc725Y = await this.supportsInterface(
       address,
-      INTERFACE_IDS.ERC725Y,
+      ERC725Y_INTERFACE_IDS['3.0'],
     );
 
     if (isErc725Y) {
@@ -70,7 +74,7 @@ export class EthereumProviderWrapper {
 
     const isErc725Yv200 = await this.supportsInterface(
       address,
-      INTERFACE_IDS.ERC725Y_v200,
+      ERC725Y_INTERFACE_IDS['2.0'],
     );
 
     if (isErc725Yv200) {
@@ -81,7 +85,7 @@ export class EthereumProviderWrapper {
 
     const isErc725YLegacy = await this.supportsInterface(
       address,
-      INTERFACE_IDS.ERC725Y_LEGACY,
+      ERC725Y_INTERFACE_IDS.legacy,
     );
 
     return isErc725YLegacy

--- a/src/providers/web3ProviderWrapper.ts
+++ b/src/providers/web3ProviderWrapper.ts
@@ -28,7 +28,7 @@ import { JsonRpc } from '../types/JsonRpc';
 import { Method } from '../types/Method';
 import { constructJSONRPC, decodeResult } from '../lib/provider-wrapper-utils';
 import { ProviderTypes } from '../types/provider';
-import { ERC725_VERSION, INTERFACE_IDS } from '../lib/constants';
+import { ERC725_VERSION, ERC725Y_INTERFACE_IDS } from '../lib/constants';
 
 // TS can't get the types from the import...
 // @ts-ignore
@@ -61,7 +61,7 @@ export class Web3ProviderWrapper {
   async getErc725YVersion(address: string): Promise<ERC725_VERSION> {
     const isErc725Y = await this.supportsInterface(
       address,
-      INTERFACE_IDS.ERC725Y,
+      ERC725Y_INTERFACE_IDS['3.0'],
     );
 
     if (isErc725Y) {
@@ -70,7 +70,7 @@ export class Web3ProviderWrapper {
 
     const isErc725Yv200 = await this.supportsInterface(
       address,
-      INTERFACE_IDS.ERC725Y_v200,
+      ERC725Y_INTERFACE_IDS['2.0'],
     );
 
     if (isErc725Yv200) {
@@ -81,7 +81,7 @@ export class Web3ProviderWrapper {
 
     const isErc725YLegacy = await this.supportsInterface(
       address,
-      INTERFACE_IDS.ERC725Y_LEGACY,
+      ERC725Y_INTERFACE_IDS.legacy,
     );
 
     return isErc725YLegacy


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

Refactor?
This PR suggest a different versioning for ERC725Y interface IDs for the `constants.js` file.

### What is the current behaviour (you can also link to an open issue here)?

In the file `constants.js`, the interface IDs do not provide context about which version of the [ERC725Y smart contract](https://github.com/ERC725Alliance/ERC725) they refer to.
The comments about the version refer to the [LUKSO smart contracts](https://github.com/lukso-network/lsp-smart-contracts/)

### What is the new behaviour (if this is a feature change)?

Suggest a different naming for these constants values, that reflect the versioning of the interface IDs changes based on the release of `@erc725/smart-contracts`
