### PR TITLE
feat: enable passing a full instance of web

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -89,6 +89,11 @@ describe('Running @erc725/erc725.js tests...', () => {
     }
   });
 
+  it('should instantiate when giving a web3 instance as provider', async () => {
+    const web3 = new Web3('https://rpc.l14.lukso.network');
+    const erc725 = new ERC725(mockSchema, address, web3);
+  });
+
   describe('isValidSignature', () => {
     it('should return true if the signature is valid [mock HttpProvider]', async () => {
       const provider = new HttpProvider({ returnData: [] }, [], true); // we mock a valid return response (magic number)

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,10 @@ export class ERC725 {
     )
       return new Web3ProviderWrapper(providerOrProviderWrapper);
 
+    if (typeof providerOrProviderWrapper.currentProvider == 'object') {
+      return new Web3ProviderWrapper(providerOrProviderWrapper.currentProvider);
+    }
+
     throw new Error(
       `Incorrect or unsupported provider ${providerOrProviderWrapper}`,
     );


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

**feature**

### What is the current behaviour (you can also link to an open issue here)?

So far, it is required to instantiate web3.js in the following way so to give the provider when creating an instance of erc725.js.

```js
// important statement..

// Parameters for ERC725 Instance
const provider = new Web3.providers.HttpProvider("https://rpc.l14.lukso.network");  // require to use an Http Provider
const config = { ipfsGateway: "https://2eff.lukso.dev/ipfs" };

const universalProfile = new ERC725(UniversalProfileSchema, SAMPLE_PROFILE_ADDRESS, provider, config);
```

This require either to instantiate Web3.js as an HTTP Provider (not recommended, as the HTTP provider from web3.js does not support subscriptions. Or to grab the `.currentProvider` from the web3 instance, as shown below.

```js
// important statement..

// Parameters for ERC725 Instance
const web3 = new Web3("https://rpc.l14.lukso.network");
const config = { ipfsGateway: "https://2eff.lukso.dev/ipfs" };

// need to grab the .currentProvider so to instantiate
const universalProfile = new ERC725(UniversalProfileSchema, SAMPLE_PROFILE_ADDRESS, web3.currentProvider, config);
```

or to 

### What is the new behaviour (if this is a feature change)?

Offer the possibility to provide a complete web3 instance, and let the library grab the `.currentProvider` automatically under the hood by default.

```js
// important statement..

// Parameters for ERC725 Instance
const web3 = new Web3("https://rpc.l14.lukso.network");
const config = { ipfsGateway: "https://2eff.lukso.dev/ipfs" };

// let erc725.js grab the .currentProvider by default if passing a full instance of web3
const universalProfile = new ERC725(UniversalProfileSchema, SAMPLE_PROFILE_ADDRESS, web3, config);
```

### Other information:

This PR is missing some tests to ensure the new behaviour correctly. 🧪 
To be discussed on how to test this new instantiation method correctly (if accepted).
