### PR TITLE
Update JsonRpc eth_call parameters

### DIFF
--- a/src/lib/provider-wrapper-utils.ts
+++ b/src/lib/provider-wrapper-utils.ts
@@ -64,10 +64,10 @@ export function constructJSONRPC(
       {
         to: address,
         gas: METHODS[method].gas,
-        gasPrice: METHODS[method].gasPrice,
         value: METHODS[method].value,
         data,
       },
+      'latest',
     ],
     id: idCount,
   };

--- a/src/providers/ethereumProviderWrapper.ts
+++ b/src/providers/ethereumProviderWrapper.ts
@@ -221,7 +221,6 @@ export class EthereumProviderWrapper {
     return {
       to: address,
       gas: METHODS[method].gas,
-      gasPrice: METHODS[method].gasPrice,
       value: METHODS[method].value,
       data,
     };

--- a/src/providers/ethereumProviderWrapper.ts
+++ b/src/providers/ethereumProviderWrapper.ts
@@ -30,7 +30,7 @@ import {
   METHODS,
 } from '../lib/constants';
 import { decodeResult as decodeResultUtils } from '../lib/provider-wrapper-utils';
-import { JsonRpcEthereumProvider } from '../types/JsonRpc';
+import { JsonRpcEthereumProviderParams } from '../types/JsonRpc';
 import { Method } from '../types/Method';
 import { ProviderTypes } from '../types/provider';
 
@@ -53,7 +53,7 @@ export class EthereumProviderWrapper {
 
   async getOwner(address: string) {
     const params = this.constructJSONRPC(address, Method.OWNER);
-    const result = await this.callContract([params]);
+    const result = await this.callContract(params);
     if (result.error) {
       throw result.error;
     }
@@ -102,13 +102,13 @@ export class EthereumProviderWrapper {
   async supportsInterface(address: string, interfaceId: string) {
     return this.decodeResult(
       Method.SUPPORTS_INTERFACE,
-      await this.callContract([
+      await this.callContract(
         this.constructJSONRPC(
           address,
           Method.SUPPORTS_INTERFACE,
           `${interfaceId}${'00000000000000000000000000000000000000000000000000000000'}`,
         ),
-      ]),
+      ),
     );
   }
 
@@ -125,9 +125,9 @@ export class EthereumProviderWrapper {
       [hash, signature],
     );
 
-    const result = await this.callContract([
+    const result = await this.callContract(
       this.constructJSONRPC(address, Method.IS_VALID_SIGNATURE, encodedParams),
-    ]);
+    );
 
     if (result.error) {
       throw result.error;
@@ -172,13 +172,13 @@ export class EthereumProviderWrapper {
     address: string,
     keyHashes: string[],
   ): Promise<GetDataReturn[]> {
-    const encodedResults = await this.callContract([
+    const encodedResults = await this.callContract(
       this.constructJSONRPC(
         address,
         Method.GET_DATA,
         abiCoder.encodeParameter('bytes32[]', keyHashes),
       ),
-    ]);
+    );
 
     const decodedValues = this.decodeResult(Method.GET_DATA, encodedResults);
 
@@ -195,9 +195,9 @@ export class EthereumProviderWrapper {
     // Here we could use `getDataMultiple` instead of sending multiple calls to `getData`
     // But this is already legacy and it won't be used anymore..
     const encodedResultsPromises = keyHashes.map((keyHash) =>
-      this.callContract([
+      this.callContract(
         this.constructJSONRPC(address, Method.GET_DATA_LEGACY, keyHash),
-      ]),
+      ),
     );
 
     const decodedResults = await Promise.all(encodedResultsPromises);
@@ -213,17 +213,20 @@ export class EthereumProviderWrapper {
     address: string,
     method: Method,
     methodParam?: string,
-  ): JsonRpcEthereumProvider {
+  ): (JsonRpcEthereumProviderParams | string)[] {
     const data = methodParam
       ? METHODS[method].sig + methodParam.replace('0x', '')
       : METHODS[method].sig;
 
-    return {
-      to: address,
-      gas: METHODS[method].gas,
-      value: METHODS[method].value,
-      data,
-    };
+    return [
+      {
+        to: address,
+        value: METHODS[method].value,
+        gas: METHODS[method].gas,
+        data,
+      },
+      'latest',
+    ];
   }
 
   private async callContract(params: any) {

--- a/src/providers/web3ProviderWrapper.ts
+++ b/src/providers/web3ProviderWrapper.ts
@@ -99,16 +99,15 @@ export class Web3ProviderWrapper {
     address: string,
     interfaceId: string,
   ): Promise<boolean> {
-    return decodeResult(
-      Method.SUPPORTS_INTERFACE,
-      await this.callContract(
-        constructJSONRPC(
-          address,
-          Method.SUPPORTS_INTERFACE,
-          `${interfaceId}${'00000000000000000000000000000000000000000000000000000000'}`,
-        ),
+    const result = await this.callContract(
+      constructJSONRPC(
+        address,
+        Method.SUPPORTS_INTERFACE,
+        `${interfaceId}${'00000000000000000000000000000000000000000000000000000000'}`,
       ),
     );
+
+    return decodeResult(Method.SUPPORTS_INTERFACE, result);
   }
 
   /**
@@ -200,6 +199,7 @@ export class Web3ProviderWrapper {
         constructJSONRPC(address, Method.GET_DATA_LEGACY, keyHashes[index]),
       );
     }
+
     const results: any = await this.callContract(payload);
 
     return payload.map<GetDataReturn>((payloadCall, index) => ({
@@ -215,6 +215,7 @@ export class Web3ProviderWrapper {
     return new Promise((resolve, reject) => {
       // Send old web3 method with callback to resolve promise
       // This is deprecated: https://docs.metamask.io/guide/ethereum-provider.html#ethereum-send-deprecated
+
       this.provider.send(payload, (e, r) => {
         if (e) {
           reject(e);

--- a/src/types/JsonRpc.ts
+++ b/src/types/JsonRpc.ts
@@ -5,10 +5,10 @@ export interface JsonRpc {
     {
       to: string;
       gas: string;
-      gasPrice: string;
       value: string;
       data;
     },
+    'latest',
   ];
   id: number;
 }
@@ -16,7 +16,6 @@ export interface JsonRpc {
 export interface JsonRpcEthereumProvider {
   to: string;
   gas: string;
-  gasPrice: string;
   value: string;
   data;
 }

--- a/src/types/JsonRpc.ts
+++ b/src/types/JsonRpc.ts
@@ -13,7 +13,7 @@ export interface JsonRpc {
   id: number;
 }
 
-export interface JsonRpcEthereumProvider {
+export interface JsonRpcEthereumProviderParams {
   to: string;
   gas: string;
   value: string;


### PR DESCRIPTION
Fixes issue where data cannot be fetched from l16 closes #193 

eth_call specs are different from what was implemented:
- Added 'latest' tag
- Removed gasPrice so call does not fail with gas error

Tested and this now works with both l14 and l16

https://github.com/ethereum/go-ethereum/issues/21108
https://www.quicknode.com/docs/ethereum/eth_call