### PR TITLE
Incorrect valueType in LSP6KeyManager.json

### DIFF
--- a/schemas/LSP6KeyManager.json
+++ b/schemas/LSP6KeyManager.json
@@ -38,7 +38,7 @@
     "name": "AddressPermissions:AllowedERC725YKeys:<address>",
     "key": "0x4b80742de2bf90b8b4850000<address>",
     "keyType": "MappingWithGrouping",
-    "valueType": "bytes4[]",
-    "valueContent": "Bytes4"
+    "valueType": "bytes32[]",
+    "valueContent": "Bytes32"
   }
 ]


### PR DESCRIPTION
Bug 

Incorrect `valueType` and `valueContent` in `AddressPermissions:AllowedERC725YKeys` permission, update to correct values as specified in docs https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-6-KeyManager.md#addresspermissionsallowederc725ykeysaddress


