### PR TITLE
fix: Change the reference to old LSP7 interface id to a random value

### DIFF
--- a/src/lib/decodeData.test.ts
+++ b/src/lib/decodeData.test.ts
@@ -183,8 +183,8 @@ describe('tuple', () => {
       {
         valueContent: '(Bytes4,Number)',
         valueType: '(bytes4,bytes8)',
-        encodedValue: '0xe33f65c3000000000000000c',
-        decodedValue: ['0xe33f65c3', '12'],
+        encodedValue: '0x5fcaac27000000000000000c',
+        decodedValue: ['0x5fcaac27', '12'],
       },
     ]; // TODO: add more cases? Address, etc.
 

--- a/src/lib/decodeData.test.ts
+++ b/src/lib/decodeData.test.ts
@@ -183,8 +183,8 @@ describe('tuple', () => {
       {
         valueContent: '(Bytes4,Number)',
         valueType: '(bytes4,bytes8)',
-        encodedValue: '0x5fcaac27000000000000000c',
-        decodedValue: ['0x5fcaac27', '12'],
+        encodedValue: '0xdeadbeaf000000000000000c',
+        decodedValue: ['0xdeadbeaf', '12'],
       },
     ]; // TODO: add more cases? Address, etc.
 

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -282,8 +282,8 @@ describe('utils', () => {
       {
         valueContent: '(Bytes4,Number)',
         valueType: '(bytes4,bytes8)',
-        encodedValue: '0xe33f65c30000000000000010',
-        decodedValue: ['0xe33f65c3', 16],
+        encodedValue: '0x5fcaac270000000000000010',
+        decodedValue: ['0x5fcaac27', 16],
       },
     ]; // we may need to add more test cases! Address, etc.
 

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -282,8 +282,8 @@ describe('utils', () => {
       {
         valueContent: '(Bytes4,Number)',
         valueType: '(bytes4,bytes8)',
-        encodedValue: '0x5fcaac270000000000000010',
-        decodedValue: ['0x5fcaac27', 16],
+        encodedValue: '0xdeadbeaf0000000000000010',
+        decodedValue: ['0xdeadbeaf', 16],
       },
     ]; // we may need to add more test cases! Address, etc.
 


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

fix

### Other information:

Change the reference of old LSP7 interface id  to a random value as it is not relevant for the tests.
- `0xe33f65c3` to `0xdeadbeef`