### PR TITLE
feat: add supportsSchema

### DIFF
--- a/src/constants/schemas.ts
+++ b/src/constants/schemas.ts
@@ -1,0 +1,27 @@
+/*
+    This file is part of @erc725/erc725.js.
+    @erc725/erc725.js is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    @erc725/erc725.js is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License
+    along with @erc725/erc725.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+export enum LSPSchemaType {
+  // LSPs which are storage schemas
+  LSP3UniversalProfile = 'LSP3UniversalProfile',
+  LSP4DigitalAssetMetadata = 'LSP4DigitalAssetMetadata',
+  LSP9Vault = 'LSP9Vault',
+
+  /**
+        NOTE: LSP5ReceivedAssets, LSP10ReceivedVaults, and LSP12IssuedAssets 
+        are not included as an LSPType to check against an interface ID or 
+        schema standard, as they are purely metadata standards, which should
+        be performed individually.
+      */
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,8 @@ import { decodeData } from './lib/decodeData';
 import { getDataFromExternalSources } from './lib/getDataFromExternalSources';
 import { DynamicKeyParts } from './types/dynamicKeys';
 import { getData } from './lib/getData';
-import { supportsInterface } from './lib/detector';
+import { supportsInterface, supportsSchema } from './lib/detector';
+import { AddressProviderOptions } from './constants/interfaces';
 
 /* eslint-disable-next-line */
 const HttpProvider = require('web3-providers-http');
@@ -575,6 +576,52 @@ export class ERC725 {
       address: options.address,
       provider: this.initializeProvider(options.rpcUrl),
     });
+  }
+
+  /**
+   * Check if the ERC725 object supports a certain schema.
+   *
+   * @param schemaKeyOrName Schema key or supported schema name.
+   * @param schema Optional ERC725JSONSchema of the key.
+   */
+  async supportsSchema(
+    schemaKeyOrName: string,
+    schema?: ERC725JSONSchema,
+  ): Promise<boolean> {
+    const { address, provider } = this.getAddressAndProvider();
+
+    return supportsSchema(schemaKeyOrName, { address, provider }, schema);
+  }
+
+  /**
+   * Check if the key value store of a smart contract
+   * supports a specific schema.
+   *
+   * @param schemaKeyOrName Schema key or supported schema name.
+   * @param options Object with address and provider.
+   * @param schema ERC725JSONSchema of the key.
+   */
+  static async supportsSchema(
+    schemaKeyOrName: string,
+    options: AddressProviderOptions,
+    schema?: ERC725JSONSchema,
+  ): Promise<boolean> {
+    if (!isAddress(options.address)) {
+      throw new Error('Invalid address');
+    } else if (!options.provider) {
+      throw new Error('Missing provider');
+    } else if (!schema) {
+      throw new Error('Missing schema');
+    }
+
+    return supportsSchema(
+      schemaKeyOrName,
+      {
+        address: options.address,
+        provider: this.initializeProvider(options.provider),
+      },
+      schema,
+    );
   }
 }
 

--- a/src/lib/detector.ts
+++ b/src/lib/detector.ts
@@ -25,6 +25,15 @@ import {
   AddressProviderOptions,
   INTERFACE_IDS_0_7_0,
 } from '../constants/interfaces';
+import { LSPSchemaType } from '../constants/schemas';
+import { ERC725Options } from '../types/Config';
+
+import { ERC725JSONSchema } from '../types/ERC725JSONSchema';
+import lsp3Schema from '../../schemas/LSP3UniversalProfileMetadata.json';
+import lsp4Schema from '../../schemas/LSP4DigitalAsset.json';
+import lsp9Schema from '../../schemas/LSP9Vault.json';
+
+import { getData } from './getData';
 
 /**
  * Check if a smart contract address
@@ -53,4 +62,103 @@ export const supportsInterface = async (
   } catch (error) {
     throw new Error(`Error checking the interface: ${error}`);
   }
+};
+
+/**
+ * Find the SupportedStandard schema object
+ * out of all supported schema objects of the LSP.
+ *
+ * @param schemas Array of LSP schemas
+ * @returns SupportedStandard schema
+ */
+const getSupportedStandardSchema = (schemas: ERC725JSONSchema[]) => {
+  try {
+    const results = schemas.filter((schema) => {
+      return schema.name.startsWith('SupportedStandards:');
+    });
+
+    if (results.length === 0) {
+      return null;
+    }
+
+    return results[0];
+  } catch (error) {
+    return null;
+  }
+};
+
+const lspSchemaOptions: Record<LSPSchemaType, any> = {
+  [LSPSchemaType.LSP3UniversalProfile]: {
+    schema: getSupportedStandardSchema(lsp3Schema as ERC725JSONSchema[]),
+  },
+  [LSPSchemaType.LSP4DigitalAssetMetadata]: {
+    schema: getSupportedStandardSchema(lsp4Schema as ERC725JSONSchema[]),
+  },
+  [LSPSchemaType.LSP9Vault]: {
+    schema: getSupportedStandardSchema(lsp9Schema as ERC725JSONSchema[]),
+  },
+};
+
+/**
+ * Check if the key value store of the smart
+ * contract supports a certain schema.
+ *
+ * @param schemaKey Schema key or supported schema name
+ * @param schemaOptions Object with address and provider
+ * @param schema ERC725JSONSchema of the key
+ */
+export const supportsSchema = async (
+  schemaKeyOrName: string,
+  schemaOptions: AddressProviderOptions,
+  schema?: ERC725JSONSchema,
+): Promise<boolean> => {
+  const erc725Options: ERC725Options = {
+    // @ts-ignore schema can be null here, since we check later (knownSchema)
+    schemas: [schema],
+    address: schemaOptions.address,
+    provider: schemaOptions.provider,
+  };
+
+  let plainSchemaName = '';
+  let knownSchema: ERC725JSONSchema;
+
+  // If full schema name was used, trim down
+  if (schemaKeyOrName.startsWith('SupportedStandards:')) {
+    plainSchemaName = schemaKeyOrName.substring(19);
+  } else {
+    plainSchemaName = schemaKeyOrName;
+  }
+
+  // Look if there is a key to the schema name
+  let plainSchemaKey: string;
+  if (lspSchemaOptions[plainSchemaName].schema.key) {
+    plainSchemaKey = lspSchemaOptions[plainSchemaName].schema.key;
+  } else {
+    plainSchemaKey = schemaKeyOrName;
+  }
+
+  if (!schema) {
+    if (lspSchemaOptions[plainSchemaName].schema) {
+      knownSchema = lspSchemaOptions[plainSchemaName].schema;
+      erc725Options.schemas = [knownSchema];
+    } else {
+      throw new Error(
+        `There is no default schema for schemaKeyOrName: ${schemaKeyOrName}. Please provide one within the options parameter.`,
+      );
+    }
+
+    try {
+      const schemaContents = await getData(erc725Options, plainSchemaKey);
+
+      if (!schema) {
+        // @ts-ignore .value does exist on getData return value
+        return schemaContents.value === knownSchema.valueContent;
+      }
+      // @ts-ignore .value does exist on getData return value
+      return schemaContents.value === schema.valueContent;
+    } catch (error) {
+      throw new Error(`Error checking the schema: ${error}`);
+    }
+  }
+  return false;
 };


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

This PR introduces schema key checkups as standalone modular function within the library that can be called directly on the ERC725 object or a custom smart contract address. For convenience, the detection tool can not only handle schema keys, but also a variety of names.

### What is the current behaviour (you can also link to an open issue here)?

At the moment, schema detection has to be done by calling `getData` and comparing the contents of the key value store manually.

potentially closes #235 

### What is the new behaviour (if this is a feature change)?

You can use `myERC725.supportsSchema(schemaKeyOrName, schema?)` or `ERC725.supportsSchema(schemaKeyOrName, options, schema?)` to check if the ERC725 object or smart contract supports a specific schema. When you use the function on your instantiated ERC725 object, it will use its address and provider by default. Otherwise, you need to specify them in the options parameter.

### Other information:

The `schemaName` can be found and edited in src/constants/interfaces. For LSPs, the schemas are taken from the `schemas/` folder.

#### Default supported schema names:

```
LSP3UniversalProfile,
LSP4DigitalAssetMetadata,
LSP9Vault,
SupportedStandard:LSP3UniversalProfile,
SupportedStandard:LSP4DigitalAssetMetadata,
SupportedStandard:LSP9Vault
```

### TODO

- [ ] close discussion on #235 
- [ ] add documentation to `docs/classes/ERC725.md`
- [ ] add function tests to `src/lib/detector.test.ts`
- [ ] add class tests to `src/index.test.ts`