### PR TITLE
Fix return type for `fetchData`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ import {
   DecodeDataInput,
   DecodeDataOutput,
   EncodeDataInput,
+  FetchDataOutput,
 } from './types/decodeData';
 import { GetDataDynamicKey, GetDataInput } from './types/GetData';
 import { decodeData } from './lib/decodeData';
@@ -208,13 +209,13 @@ export class ERC725 {
 
   async fetchData(
     keyOrKeys?: Array<string | GetDataDynamicKey>,
-  ): Promise<DecodeDataOutput[]>;
+  ): Promise<FetchDataOutput[]>;
   async fetchData(
     keyOrKeys?: string | GetDataDynamicKey,
-  ): Promise<DecodeDataOutput>;
+  ): Promise<FetchDataOutput>;
   async fetchData(
     keyOrKeys?: GetDataInput,
-  ): Promise<DecodeDataOutput | DecodeDataOutput[]> {
+  ): Promise<FetchDataOutput | FetchDataOutput[]> {
     let keyNames: Array<string | GetDataDynamicKey>;
 
     if (Array.isArray(keyOrKeys)) {

--- a/src/types/decodeData.ts
+++ b/src/types/decodeData.ts
@@ -20,6 +20,16 @@ export interface DecodeDataOutput {
   key: string;
 }
 
+export interface FetchDataOutput {
+  value:
+    | string
+    | string[]
+    | { LSP3Profile: Record<string, any> }
+    | Record<string, any>;
+  name: string;
+  key: string;
+}
+
 export interface GetDataExternalSourcesOutput extends DecodeDataOutput {
   value: any;
 }


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
Fix the type of the object returned by fetchData function.

### What is the current behaviour (you can also link to an open issue here)?
When fetching profile `await erc725.fetchData("LSP3Profile")` expects that it will return `DecodeDataOutput` with `value` field. But value is typed as `string | string[] | URLDataWithHash` while in `value`  I get profile object
```
{
LSP3Profile: 
{...}
}
```
[Link to open issue](https://github.com/ERC725Alliance/erc725.js/issues/192)

### What is the new behaviour (if this is a feature change)?
A new type `FetchDataOutput` was created with the following properties :
```
FetchDataOutput {
  value:
    | string
    | string[]
    | { LSP3Profile: Record<string, any> }
    | Record<string, any>;
  name: string;
  key: string;
}
```