### PR TITLE
Feat/decode key hash

### DIFF
--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -550,6 +550,74 @@ myErc725.encodeKeyName('LSP3Profile');
 
 ---
 
+## decodeMappingKey
+
+```js
+ERC725.decodeMappingKey(keyNameOrSchema, keyHash);
+```
+
+Decode the values of the dynamic parts of a hashed key used on an [ERC725Y contract](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725y) according to the [LSP2 ERC725Y JSON Schema Standard](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md).
+
+:::info
+
+`decodeMappingKey` is available as either a static or non-static method so can be called without instantiating an ERC725 object.
+
+:::
+
+#### Parameters
+
+##### 1. `keyHash` - String
+
+The bytes32 key hash that needs to be decoded
+
+##### 2. `keyNameOrSchema` - String or ERC725JSONSchema
+
+The key name or erc725y json schema associated to the key hash to decode, for instance: `MySuperKey:<address>`.
+
+#### Returns
+
+| Name              | Type                                                 | Description                                      |
+|:------------------|:-----------------------------------------------------|:-------------------------------------------------|
+| `dynamicKeyParts` | {type: string, value: string OR number OR boolean}[] | The dynamic key parts decoded from the key hash. |
+
+
+#### Example
+
+```javascript title="Decode the mapping key"
+ERC725.decodeMappingKey('0x35e6950bc8d21a1699e50000cafecafecafecafecafecafecafecafecafecafe', 'MyKeyName:<address>');
+// [{
+//   type: 'address',
+//   value: '0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe'
+// }]
+
+ERC725.decodeMappingKey('0x35e6950bc8d21a1699e5000000000000000000000000000000000000f342d33d', 'MyKeyName:<uint32>');
+// [{ type: 'uint32', value: 4081242941 }]
+
+ERC725.decodeMappingKey('0x35e6950bc8d21a1699e5000000000000000000000000000000000000abcd1234', 'MyKeyName:<bytes4>');
+// [{ type: 'bytes4', value: 'abcd1234' }]
+
+ERC725.decodeMappingKey('0x35e6950bc8d21a1699e50000aaaabbbbccccddddeeeeffff1111222233334444', 'MyKeyName:<bytes32>');
+// [{
+//   type: 'bytes32',
+//   value: 'aaaabbbbccccddddeeeeffff1111222233334444'
+// }]
+
+ERC725.decodeMappingKey('0x35e6950bc8d21a1699e500000000000000000000000000000000000000000001', 'MyKeyName:<bool>');
+// [{ type: 'bool', value: true }]
+
+ERC725.decodeMappingKey('0x35e6950bc8d20000ffff000000000000000000000000000000000000f342d33d', 'MyKeyName:<bytes2>:<uint32>');
+// [
+//   { type: 'bytes2', value: 'ffff' },
+//   { type: 'uint32', value: 4081242941 }
+// ]
+
+// This method is also available on the instance:
+myErc725.decodeMappingKey('0x35e6950bc8d20000ffff000000000000000000000000000000000000f342d33d', 'MyKeyName:<bytes2>:<uint32>');
+```
+
+---
+
+
 ## encodePermissions
 
 ```js

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1275,3 +1275,34 @@ describe('supportsInterface', () => {
 
   // TODO: add test to test the actual behavior of the function.
 });
+
+describe('decodeMappingKey', () => {
+  const erc725Instance = new ERC725([]);
+
+  it('is available on instance and class', () => {
+    assert.deepStrictEqual(
+      ERC725.decodeMappingKey(
+        '0x35e6950bc8d21a1699e50000cafecafecafecafecafecafecafecafecafecafe',
+        'MyKeyName:<address>',
+      ),
+      [
+        {
+          type: 'address',
+          value: '0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe',
+        },
+      ],
+    );
+    assert.deepStrictEqual(
+      erc725Instance.decodeMappingKey(
+        '0x35e6950bc8d21a1699e50000cafecafecafecafecafecafecafecafecafecafe',
+        'MyKeyName:<address>',
+      ),
+      [
+        {
+          type: 'address',
+          value: '0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe',
+        },
+      ],
+    );
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,9 +57,10 @@ import {
 import { GetDataDynamicKey, GetDataInput } from './types/GetData';
 import { decodeData } from './lib/decodeData';
 import { getDataFromExternalSources } from './lib/getDataFromExternalSources';
-import { DynamicKeyParts } from './types/dynamicKeys';
+import { DynamicKeyPart, DynamicKeyParts } from './types/dynamicKeys';
 import { getData } from './lib/getData';
 import { supportsInterface } from './lib/detector';
+import { decodeMappingKey } from './lib/decodeMappingKey';
 
 /* eslint-disable-next-line */
 const HttpProvider = require('web3-providers-http');
@@ -534,6 +535,36 @@ export class ERC725 {
    */
   encodeKeyName(keyName: string, dynamicKeyParts?: DynamicKeyParts): string {
     return encodeKeyName(keyName, dynamicKeyParts);
+  }
+
+  /**
+   * Decodes a hashed key used on an ERC725Y contract according to LSP2 ERC725Y JSONSchema standard.
+   *
+   * @param {string} keyHash Key hash that needs to be decoded.
+   * @param {string | ERC725JSONSchema} keyNameOrSchema Key name following schema specifications or ERC725Y JSON Schema to follow in order to decode the key.
+   * @link https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md ERC725YJsonSchema standard.
+   * @returns {DynamicKeyPart[]} The Array with all the key decoded dynamic parameters. Each object have an attribute type and value.
+   */
+  static decodeMappingKey(
+    keyHash: string,
+    keyNameOrSchema: string | ERC725JSONSchema,
+  ): DynamicKeyPart[] {
+    return decodeMappingKey(keyHash, keyNameOrSchema);
+  }
+
+  /**
+   * Decodes a hashed key used on an ERC725Y contract according to LSP2 ERC725Y JSONSchema standard.
+   *
+   * @param {string} keyHash Key hash that needs to be decoded.
+   * @param {string | ERC725JSONSchema} keyNameOrSchema Key name following schema specifications or ERC725Y JSON Schema to follow in order to decode the key.
+   * @link https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md ERC725YJsonSchema standard.
+   * @returns {DynamicKeyPart[]} The Array with all the key decoded dynamic parameters. Each object have an attribute type and value.
+   */
+  decodeMappingKey(
+    keyHash: string,
+    keyNameOrSchema: string | ERC725JSONSchema,
+  ): DynamicKeyPart[] {
+    return decodeMappingKey(keyHash, keyNameOrSchema);
   }
 
   /**

--- a/src/lib/decodeMappingKey.test.ts
+++ b/src/lib/decodeMappingKey.test.ts
@@ -1,0 +1,209 @@
+/*
+    This file is part of @erc725/erc725.js.
+    @erc725/erc725.js is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    @erc725/erc725.js is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License
+    along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/* eslint-disable no-unused-expressions */
+
+import { expect } from 'chai';
+import { decodeMappingKey } from './decodeMappingKey';
+
+describe('decodeDynamicKeyParts', () => {
+  const records = [
+    {
+      key: {
+        name: 'MyKeyName:<address>',
+        encoded:
+          '0x35e6950bc8d21a1699e50000cafecafecafecafecafecafecafecafecafecafe',
+      },
+      dynamicKeyParts: [
+        {
+          type: 'address',
+          value: '0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe',
+        },
+      ],
+    },
+    {
+      key: {
+        name: 'MyKeyName:<uint32>',
+        encoded:
+          '0x35e6950bc8d21a1699e5000000000000000000000000000000000000f342d33d',
+      },
+      dynamicKeyParts: [{ type: 'uint32', value: 4081242941 }],
+    },
+    {
+      key: {
+        name: 'MyKeyName:<bytes4>',
+        encoded:
+          '0x35e6950bc8d21a1699e5000000000000000000000000000000000000abcd1234',
+      },
+      dynamicKeyParts: [{ type: 'bytes4', value: 'abcd1234' }],
+    },
+    {
+      key: {
+        name: 'MyKeyName:<bytes32>',
+        encoded:
+          '0x35e6950bc8d21a1699e50000aaaabbbbccccddddeeeeffff1111222233334444',
+      },
+      dynamicKeyParts: [
+        {
+          type: 'bytes32',
+          value: 'aaaabbbbccccddddeeeeffff1111222233334444',
+        },
+      ],
+    },
+    {
+      key: {
+        name: 'MyKeyName:<bool>',
+        encoded:
+          '0x35e6950bc8d21a1699e500000000000000000000000000000000000000000001',
+      },
+      dynamicKeyParts: [{ type: 'bool', value: true }],
+    },
+    {
+      key: {
+        name: 'MyKeyName:<bool>',
+        encoded:
+          '0x35e6950bc8d21a1699e500000000000000000000000000000000000000000000',
+      },
+      dynamicKeyParts: [{ type: 'bool', value: false }],
+    },
+    {
+      key: {
+        name: 'MyKeyName:MyMapName:<address>',
+        encoded:
+          '0x35e6950bc8d275060e3c0000cafecafecafecafecafecafecafecafecafecafe',
+      },
+      dynamicKeyParts: [
+        {
+          type: 'address',
+          value: '0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe',
+        },
+      ],
+    },
+    {
+      key: {
+        name: 'MyKeyName:<bytes2>:<uint32>',
+        encoded:
+          '0x35e6950bc8d20000ffff000000000000000000000000000000000000f342d33d',
+      },
+      dynamicKeyParts: [
+        { type: 'bytes2', value: 'ffff' },
+        { type: 'uint32', value: 4081242941 },
+      ],
+    },
+    {
+      key: {
+        name: 'MyKeyName:<address>:<address>',
+        encoded:
+          '0x35e6950bc8d2abcdef110000cafecafecafecafecafecafecafecafecafecafe',
+      },
+      dynamicKeyParts: [
+        {
+          type: 'address',
+          value: '0x00000000000000000000000000000000AbCDeF11',
+        },
+        {
+          type: 'address',
+          value: '0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe',
+        },
+      ],
+    },
+    {
+      key: {
+        name: 'MyKeyName:MyMapName:<bytes32>',
+        encoded:
+          '0x35e6950bc8d275060e3c0000aaaabbbbccccddddeeeeffff1111222233334444',
+      },
+      dynamicKeyParts: [
+        {
+          type: 'bytes32',
+          value: 'aaaabbbbccccddddeeeeffff1111222233334444',
+        },
+      ],
+    },
+    {
+      key: {
+        name: 'MyKeyName:<bytes32>:<bool>',
+        encoded:
+          '0x35e6950bc8d2aaaabbbb00000000000000000000000000000000000000000001',
+      },
+      dynamicKeyParts: [
+        { type: 'bytes32', value: 'aaaabbbb' },
+        { type: 'bool', value: true },
+      ],
+    },
+  ];
+
+  it('decodes each dynamic key part', () => {
+    records.forEach((record) => {
+      const decodedDynamicKeyParts = decodeMappingKey(
+        record.key.encoded,
+        record.key.name,
+      );
+      expect(record.dynamicKeyParts.length).to.equal(
+        decodedDynamicKeyParts.length,
+      );
+      record.dynamicKeyParts.forEach((keyPart, index) => {
+        expect(keyPart.type).to.equal(decodedDynamicKeyParts[index].type);
+        expect(keyPart.value).to.equal(decodedDynamicKeyParts[index].value);
+      });
+    });
+  });
+
+  it('decodes each dynamic key part when schema as a param', () => {
+    const schema = {
+      name: 'MyKeyName:<address>',
+      key: '0x',
+      keyType: 'Singleton',
+      valueType: 'bytes',
+      valueContent: 'JSONURL',
+    };
+    const decodedDynamicKeyParts = decodeMappingKey(
+      '0x35e6950bc8d21a1699e50000cafecafecafecafecafecafecafecafecafecafe',
+      schema.name,
+    );
+    expect(decodedDynamicKeyParts.length).to.equal(1);
+    expect(decodedDynamicKeyParts[0].type).to.equal('address');
+    expect(decodedDynamicKeyParts[0].value).to.equal(
+      '0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe',
+    );
+  });
+
+  it("decodes properly if only hex key without '0x'", () => {
+    const decodedDynamicKeyParts = decodeMappingKey(
+      '35e6950bc8d21a1699e500000000000000000000000000000000000000000001',
+      'MyKeyName:<bool>',
+    );
+    expect(decodedDynamicKeyParts[0].value).to.equal(true);
+  });
+
+  it('throws if not hex encoded key', () => {
+    expect(() =>
+      decodeMappingKey(
+        '0x3234535343fXXWGWXWDSWDAEDFAEDr5434534grdgrdggrdgdrgdgrd098594334',
+        'MyKeyName:<bool>',
+      ),
+    ).to.throw(`Invalid encodedKey, must be a hexadecimal value`);
+  });
+
+  it('throws if incorrect length key', () => {
+    expect(() =>
+      decodeMappingKey(
+        '0x35e6950bc8d21a1699e50000000000000000000000000000000000000000000135e6',
+        'MyKeyName:<bool>',
+      ),
+    ).to.throw(
+      `Invalid encodedKey length, key must be 32 bytes long hexadecimal value`,
+    );
+  });
+});

--- a/src/lib/decodeMappingKey.ts
+++ b/src/lib/decodeMappingKey.ts
@@ -1,0 +1,110 @@
+/*
+    This file is part of @erc725/erc725.js.
+    @erc725/erc725.js is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    @erc725/erc725.js is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License
+    along with @erc725/erc725.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+ * @file lib/decodeMappingKey.ts
+ * @author Samuel Videau <@samuel-videau>
+ * @date 2022
+ */
+
+import { isHex } from 'web3-utils';
+import Web3 from 'web3';
+import { decodeValueType } from './encoder';
+import { ERC725JSONSchema } from '../types/ERC725JSONSchema';
+import { DynamicKeyPart } from '../types/dynamicKeys';
+
+function make32BytesLong(s: string): string {
+  return Web3.utils.padLeft(s, 64);
+}
+
+function isDynamicKeyPart(keyPartName: string): boolean {
+  return (
+    keyPartName.slice(0, 1) === '<' &&
+    keyPartName.slice(keyPartName.length - 1) === '>'
+  );
+}
+
+/**
+ * @param encodedKeyPart hashed dynamic key part
+ * @param keyPartName part of a key name
+ *
+ * @return: the decoded value of the dynamic key part and its type (ie. 'address'; 'uint256', 'bytes32', etc)
+ */
+function decodeKeyPart(
+  encodedKeyPart: string,
+  keyPartName: string,
+): DynamicKeyPart | false {
+  if (!isDynamicKeyPart(keyPartName)) return false;
+
+  let decodedKey;
+  const type = keyPartName.slice(1, keyPartName.length - 1);
+
+  if (type === 'bool')
+    decodedKey = encodedKeyPart.slice(encodedKeyPart.length - 1) === '1';
+  else if (type.includes('uint')) decodedKey = parseInt(encodedKeyPart, 16);
+  else if (type.includes('bytes')) {
+    const bytesLength = parseInt(type.replace('bytes', ''), 10) * 2;
+    const sliceFrom =
+      encodedKeyPart.length - bytesLength < 0
+        ? 0
+        : encodedKeyPart.length - bytesLength;
+    decodedKey = encodedKeyPart.slice(sliceFrom);
+  } else decodedKey = decodeValueType(type, make32BytesLong(encodedKeyPart));
+
+  return { type, value: decodedKey };
+}
+
+/**
+ * @param keyHash hashed key with the dynamic parts
+ * @param keyNameOrSchema key name of schema definitions or schema
+ *
+ * @return: all decoded dynamic key parts, with their type and value
+ */
+export function decodeMappingKey(
+  keyHash: string,
+  keyNameOrSchema: string | ERC725JSONSchema,
+): DynamicKeyPart[] {
+  let hashedKey = keyHash;
+  if (hashedKey.length === 64 && hashedKey.slice(0, 2) !== '0x')
+    hashedKey = '0x' + hashedKey;
+
+  if (hashedKey.length !== 66)
+    throw new Error(
+      `Invalid encodedKey length, key must be 32 bytes long hexadecimal value`,
+    );
+  if (!isHex(hashedKey.slice(2)))
+    throw new Error(`Invalid encodedKey, must be a hexadecimal value`);
+
+  let keyParts: string[];
+
+  if (typeof keyNameOrSchema === 'string')
+    keyParts = keyNameOrSchema.split(':');
+  else keyParts = keyNameOrSchema.name.split(':');
+
+  const dynamicParts: (DynamicKeyPart | false)[] = [];
+  switch (keyParts.length) {
+    case 2: // Mapping
+      dynamicParts.push(decodeKeyPart(hashedKey.slice(26), keyParts[1]));
+      break;
+
+    case 3: // MappingWithGrouping
+      dynamicParts.push(decodeKeyPart(hashedKey.slice(14, 22), keyParts[1]));
+      dynamicParts.push(decodeKeyPart(hashedKey.slice(26), keyParts[2]));
+      break;
+    default:
+      break;
+  }
+
+  return dynamicParts.filter((p) => p !== false) as DynamicKeyPart[];
+}

--- a/src/types/dynamicKeys.ts
+++ b/src/types/dynamicKeys.ts
@@ -8,3 +8,8 @@ export interface DynamicKeyPartInput {
   dynamicKeyParts: DynamicKeyParts;
   value: EncodeDataType;
 }
+
+export interface DynamicKeyPart {
+  type: string;
+  value: string | boolean | number;
+}


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

Feature: Decode Key Hash

This new feature would propose a function to decode a key hash, by providing, either the keyname, either the ERC725Y json schema associated to the key hash, and would return the dynamic parameters (type and value) from the key hash.

### What is the current behaviour (you can also link to an open issue here)?

No way to decode the dynamic parts of a key hash from its schema definition.
Open issue: https://github.com/ERC725Alliance/erc725.js/issues/253

### What is the new behaviour (if this is a feature change)?

Function to decode a key hash from its associated key name or erc725y json schema, returning the dynamic key parts with their type and value.

### Other information:

#### decodeKeyHash

```js
ERC725.decodeKeyHash(keyHash, keyNameOrSchema);
```

Decode the values of the dynamic parts of a hashed key used on an [ERC725Y contract](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725y) according to the [LSP2 ERC725Y JSON Schema Standard](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md).

`decodeKeyHash` is available as either a static or non-static method so can be called without instantiating an ERC725 object.

#### Parameters

##### 1. `keyHash` - String

The bytes32 key hash that needs to be decoded

##### 2. `keyNameOrSchema` - String or ERC725JSONSchema

The key name or erc725y json schema associated to the key hash to decode, for instance: `MySuperKey:<address>`.

#### Returns

| Name              | Type                                                 | Description                                      |
|:------------------|:-----------------------------------------------------|:-------------------------------------------------|
| `dynamicKeyParts` | {type: string, value: string OR number OR boolean}[] | The dynamic key parts decoded from the key hash. |


#### Example

```javascript title="Encode the key name"
ERC725.decodeKeyHash('0x35e6950bc8d21a1699e50000cafecafecafecafecafecafecafecafecafecafe', 'MyKeyName:<address>');
// [{
//   type: 'address',
//   value: '0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe'
// }]

ERC725.decodeKeyHash('0x35e6950bc8d21a1699e5000000000000000000000000000000000000f342d33d', 'MyKeyName:<uint32>');
// [{ type: 'uint32', value: 4081242941 }]

ERC725.decodeKeyHash('0x35e6950bc8d21a1699e5000000000000000000000000000000000000abcd1234', 'MyKeyName:<bytes4>');
// [{ type: 'bytes4', value: 'abcd1234' }]

ERC725.decodeKeyHash('0x35e6950bc8d21a1699e50000aaaabbbbccccddddeeeeffff1111222233334444', 'MyKeyName:<bytes32>');
// [{
//   type: 'bytes32',
//   value: 'aaaabbbbccccddddeeeeffff1111222233334444'
// }]

ERC725.decodeKeyHash('0x35e6950bc8d21a1699e500000000000000000000000000000000000000000001', 'MyKeyName:<bool>');
// [{ type: 'bool', value: true }]

ERC725.decodeKeyHash('0x35e6950bc8d20000ffff000000000000000000000000000000000000f342d33d', 'MyKeyName:<bytes2>:<uint32>');
// [
//   { type: 'bytes2', value: 'ffff' },
//   { type: 'uint32', value: 4081242941 }
// ]

// This method is also available on the instance:
myErc725.decodeKeyHash('0x35e6950bc8d20000ffff000000000000000000000000000000000000f342d33d', 'MyKeyName:<bytes2>:<uint32>');
```

---
