### PR TITLE
fix: Encode key name should parse any number (hex or decimal) for uint type

### DIFF
--- a/src/lib/encodeKeyName.test.ts
+++ b/src/lib/encodeKeyName.test.ts
@@ -110,6 +110,13 @@ describe('encodeKeyName', () => {
       dynamicKeyParts: '4081242941',
     },
     {
+      keyName: 'MyKeyName:<uint32>',
+      expectedKey:
+        '0x35e6950bc8d21a1699e5000000000000000000000000000000000000f342d33d',
+      // |--keccak256 bytes12-||--||---bytes20: keccak256()---------------|
+      dynamicKeyParts: '0xf342d33d',
+    },
+    {
       keyName: 'MyKeyName:<bytes4>',
       expectedKey:
         '0x35e6950bc8d21a1699e5000000000000000000000000000000000000abcd1234',
@@ -159,6 +166,13 @@ describe('encodeKeyName', () => {
         '0x35e6950bc8d20000ffff000000000000000000000000000000000000f342d33d',
       // |-- bytes6 --||------||--||------------ bytes20 -----------------|
       dynamicKeyParts: ['ffff', '4081242941'],
+    },
+    {
+      keyName: 'MyKeyName:<bytes2>:<uint32>',
+      expectedKey:
+        '0x35e6950bc8d20000ffff000000000000000000000000000000000000f342d33d',
+      // |-- bytes6 --||------||--||------------ bytes20 -----------------|
+      dynamicKeyParts: ['ffff', '0xf342d33d'],
     },
     {
       keyName: 'MyKeyName:<address>:<address>',
@@ -332,7 +346,19 @@ describe('encodeDynamicKeyPart', () => {
     },
     {
       type: '<uint32>',
+      value: '0xf342d33d',
+      bytes: 20,
+      expectedEncoding: '00000000000000000000000000000000f342d33d', // left padded
+    },
+    {
+      type: '<uint32>',
       value: '4081242941',
+      bytes: 2,
+      expectedEncoding: 'd33d', // left cut
+    },
+    {
+      type: '<uint32>',
+      value: '0xf342d33d',
       bytes: 2,
       expectedEncoding: 'd33d', // left cut
     },

--- a/src/lib/encodeKeyName.ts
+++ b/src/lib/encodeKeyName.ts
@@ -101,8 +101,7 @@ export const encodeDynamicKeyPart = (
       // NOTE: we could verify if the number given is not too big for the given size.
       // e.g.: uint8 max value is 255, uint16 is 65535...
 
-      const hexNumber = numberToHex(parseInt(value, 10)).slice(2);
-
+      const hexNumber = numberToHex(value).slice(2);
       if (hexNumber.length <= bytes * 2) {
         return padLeft(hexNumber, bytes * 2);
       }


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
bug fix

### What is the current behaviour (you can also link to an open issue here)?
uint type takes only decimals

### What is the new behaviour (if this is a feature change)?
uint type can take hex and decimals

### Other information:
N/A