### PR TITLE
fix: removed ERC725JSONSchemaKeyType duplicate value

### DIFF
--- a/src/types/ERC725JSONSchema.ts
+++ b/src/types/ERC725JSONSchema.ts
@@ -2,7 +2,6 @@
 
 export type ERC725JSONSchemaKeyType =
   | 'Singleton'
-  | 'Mapping'
   | 'Array'
   | 'Mapping'
   | 'MappingWithGrouping';


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

Minor refactoring.

### What is the current behaviour (you can also link to an open issue here)?

### What is the new behaviour (if this is a feature change)?

### Other information:

`'Mapping'` was mentioned twice.

```js
export type ERC725JSONSchemaKeyType =
  ...
  | 'Mapping'
  ...
  | 'Mapping'
  ...
```

