### PR TITLE
Release v0.17.2

### DIFF
--- a/schemas/LSP1UniversalReceiverDelegate.json
+++ b/schemas/LSP1UniversalReceiverDelegate.json
@@ -5,5 +5,12 @@
     "keyType": "Singleton",
     "valueType": "address",
     "valueContent": "Address"
+  },
+  {
+    "name": "LSP1UniversalReceiverDelegate:<bytes32>",
+    "key": "0x0cfc51aec37c55a4d0b10000<bytes32>",
+    "keyType": "Mapping",
+    "valueType": "address",
+    "valueContent": "Address"
   }
 ]

--- a/schemas/LSP3UniversalProfileMetadata.json
+++ b/schemas/LSP3UniversalProfileMetadata.json
@@ -28,13 +28,6 @@
     "valueContent": "(Bytes4,Number)"
   },
   {
-    "name": "LSP5ReceivedAssetsMap:<address>",
-    "key": "0x812c4334633eb816c80d0000<address>",
-    "keyType": "Mapping",
-    "valueType": "(bytes4,bytes8)",
-    "valueContent": "(Bytes4,Number)"
-  },
-  {
     "name": "LSP5ReceivedAssets[]",
     "key": "0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b",
     "keyType": "Array",
@@ -42,9 +35,30 @@
     "valueContent": "Address"
   },
   {
+    "name": "LSP5ReceivedAssetsMap:<address>",
+    "key": "0x812c4334633eb816c80d0000<address>",
+    "keyType": "Mapping",
+    "valueType": "(bytes4,bytes8)",
+    "valueContent": "(Bytes4,Number)"
+  },
+  {
     "name": "LSP1UniversalReceiverDelegate",
     "key": "0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47",
     "keyType": "Singleton",
+    "valueType": "address",
+    "valueContent": "Address"
+  },
+  {
+    "name": "LSP1UniversalReceiverDelegate:<bytes32>",
+    "key": "0x0cfc51aec37c55a4d0b10000<bytes32>",
+    "keyType": "Mapping",
+    "valueType": "address",
+    "valueContent": "Address"
+  },
+  {
+    "name": "LSP17Extension:<bytes4>",
+    "key": "0xcee78b4094da860110960000<bytes4>",
+    "keyType": "Mapping",
     "valueType": "address",
     "valueContent": "Address"
   }

--- a/schemas/LSP5ReceivedAssets.json
+++ b/schemas/LSP5ReceivedAssets.json
@@ -1,16 +1,16 @@
 [
   {
-    "name": "LSP5ReceivedAssetsMap:<address>",
-    "key": "0x812c4334633eb816c80d0000<address>",
-    "keyType": "Mapping",
-    "valueType": "(bytes4,bytes8)",
-    "valueContent": "(Bytes4,Number)"
-  },
-  {
     "name": "LSP5ReceivedAssets[]",
     "key": "0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b",
     "keyType": "Array",
     "valueType": "address",
     "valueContent": "Address"
+  },
+  {
+    "name": "LSP5ReceivedAssetsMap:<address>",
+    "key": "0x812c4334633eb816c80d0000<address>",
+    "keyType": "Mapping",
+    "valueType": "(bytes4,bytes8)",
+    "valueContent": "(Bytes4,Number)"
   }
 ]

--- a/schemas/LSP6KeyManager.json
+++ b/schemas/LSP6KeyManager.json
@@ -14,31 +14,17 @@
     "valueContent": "BitArray"
   },
   {
-    "name": "AddressPermissions:AllowedAddresses:<address>",
-    "key": "0x4b80742de2bfc6dd6b3c0000<address>",
+    "name": "AddressPermissions:AllowedCalls:<address>",
+    "key": "0x4b80742de2bf393a64c70000<address>",
     "keyType": "MappingWithGrouping",
-    "valueType": "address[]",
-    "valueContent": "Address"
+    "valueType": "(bytes4,address,bytes4)[CompactBytesArray]",
+    "valueContent": "(Bytes4,Address,Bytes4)"
   },
   {
-    "name": "AddressPermissions:AllowedFunctions:<address>",
-    "key": "0x4b80742de2bf8efea1e80000<address>",
+    "name": "AddressPermissions:AllowedERC725YDataKeys:<address>",
+    "key": "0x4b80742de2bf866c29110000<address>",
     "keyType": "MappingWithGrouping",
-    "valueType": "bytes4[]",
-    "valueContent": "Bytes4"
-  },
-  {
-    "name": "AddressPermissions:AllowedStandards:<address>",
-    "key": "0x4b80742de2bf3efa94a30000<address>",
-    "keyType": "MappingWithGrouping",
-    "valueType": "bytes4[]",
-    "valueContent": "Bytes4"
-  },
-  {
-    "name": "AddressPermissions:AllowedERC725YKeys:<address>",
-    "key": "0x4b80742de2bf90b8b4850000<address>",
-    "keyType": "MappingWithGrouping",
-    "valueType": "bytes32[]",
-    "valueContent": "Bytes32"
+    "valueType": "bytes[CompactBytesArray]",
+    "valueContent": "Bytes"
   }
 ]

--- a/schemas/LSP9Vault.json
+++ b/schemas/LSP9Vault.json
@@ -5,5 +5,26 @@
     "keyType": "Mapping",
     "valueType": "bytes4",
     "valueContent": "0x7c0334a1"
+  },
+  {
+    "name": "LSP1UniversalReceiverDelegate",
+    "key": "0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47",
+    "keyType": "Singleton",
+    "valueType": "address",
+    "valueContent": "Address"
+  },
+  {
+    "name": "LSP1UniversalReceiverDelegate:<bytes32>",
+    "key": "0x0cfc51aec37c55a4d0b10000<bytes32>",
+    "keyType": "Mapping",
+    "valueType": "address",
+    "valueContent": "Address"
+  },
+  {
+    "name": "LSP17Extension:<bytes4>",
+    "key": "0xcee78b4094da860110960000<bytes4>",
+    "keyType": "Mapping",
+    "valueType": "address",
+    "valueContent": "Address"
   }
 ]


### PR DESCRIPTION
### [0.17.2](https://github.com/ERC725Alliance/erc725.js/compare/v0.17.1...v0.17.2) (2023-03-14)

- removed ERC725JSONSchemaKeyType duplicate value ([060ee6c](https://github.com/ERC725Alliance/erc725.js/commit/060ee6ce23bda328f727140419de7590f48fc394))
- wrong web3 import ([337269e](https://github.com/ERC725Alliance/erc725.js/commit/337269eb22f82e6f44f9b8c9be4840fa6cd676ed))