### PR TITLE
feat: Add checkPermissions function

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "web3": "^1.8.2"
   },
   "dependencies": {
+    "bignumber.js": "^9.1.1",
     "ethereumjs-util": "^7.1.5",
     "web3-eth-abi": "^1.8.2",
     "web3-providers-http": "^1.8.0",

--- a/src/lib/detector.test.ts
+++ b/src/lib/detector.test.ts
@@ -64,7 +64,7 @@ describe('supportsInterface', () => {
   });
 });
 
-describe.only('checkPermissions', () => {
+describe('checkPermissions', () => {
   describe('test with single permission', () => {
     it('should throw an error when given an invalid permission string', async () => {
       const requiredPermissions = 'INVALIDPERMISSION';

--- a/src/lib/detector.test.ts
+++ b/src/lib/detector.test.ts
@@ -64,7 +64,7 @@ describe('supportsInterface', () => {
   });
 });
 
-describe.only('checkPermissions', () => {
+describe('checkPermissions', () => {
   describe('test with single permission', () => {
     it('should return true when single literal permission matches granted permissions', async () => {
       const requiredPermissions = 'CHANGEOWNER';

--- a/src/lib/detector.test.ts
+++ b/src/lib/detector.test.ts
@@ -24,7 +24,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { INTERFACE_IDS_0_7_0 } from '../constants/interfaces';
 
-import { supportsInterface } from './detector';
+import { supportsInterface, checkPermissions } from './detector';
 
 describe('supportsInterface', () => {
   it('it should return true if the contract supports the interface with name', async () => {
@@ -61,5 +61,113 @@ describe('supportsInterface', () => {
     });
 
     expect(doesSupportInterface).to.be.true;
+  });
+});
+
+describe.only('checkPermissions', () => {
+  describe('test with single permission', () => {
+    it('should return true when single literal permission matches granted permissions', async () => {
+      const requiredPermissions = 'CHANGEOWNER';
+      const grantedPermissions =
+        '0x000000000000000000000000000000000000000000000000000000000000ff51';
+      const result = checkPermissions(requiredPermissions, grantedPermissions);
+      expect(result).to.be.true;
+    });
+
+    it('should return true when single bytes32 permission matches granted permissions', async () => {
+      const requiredPermissions =
+        '0x0000000000000000000000000000000000000000000000000000000000000001';
+      const grantedPermissions =
+        '0x000000000000000000000000000000000000000000000000000000000000ff51';
+      const result = checkPermissions(requiredPermissions, grantedPermissions);
+      expect(result).to.be.true;
+    });
+
+    it('should return false when single bytes32 permission does not match granted permissions', async () => {
+      const requiredPermissions =
+        '0x0000000000000000000000000000000000000000000000000000000000000001';
+      const grantedPermissions =
+        '0x000000000000000000000000000000000000000000000000000000000000fff2';
+      const result = checkPermissions(requiredPermissions, grantedPermissions);
+      expect(result).to.be.false;
+    });
+
+    it('should return false when single literal permission does not match granted permissions', async () => {
+      const requiredPermissions = 'CHANGEOWNER';
+      const grantedPermissions =
+        '0x000000000000000000000000000000000000000000000000000000000000fff2';
+      const result = checkPermissions(requiredPermissions, grantedPermissions);
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('test with multiple permissions', () => {
+    it('should return false when one of the literal permissions does not match granted permissions', async () => {
+      const requiredPermissions = ['CHANGEPERMISSIONS', 'CALL'];
+      const grantedPermissions =
+        '0x000000000000000000000000000000000000000000000000000000000000ff51';
+      const result = checkPermissions(requiredPermissions, grantedPermissions);
+      expect(result).to.be.false;
+    });
+
+    it('should return false when one of the bytes32 permissions does not match granted permissions', async () => {
+      const requiredPermissions = [
+        '0x0000000000000000000000000000000000000000000000000000000000000004',
+        '0x0000000000000000000000000000000000000000000000000000000000000800',
+      ];
+      const grantedPermissions =
+        '0x000000000000000000000000000000000000000000000000000000000000ff51';
+      const result = checkPermissions(requiredPermissions, grantedPermissions);
+      expect(result).to.be.false;
+    });
+
+    it('should return true when all the mixed literal and bytes32 permissions match granted permissions', async () => {
+      const requiredPermissions = [
+        'CHANGEPERMISSIONS',
+        '0x0000000000000000000000000000000000000000000000000000000000000800',
+      ];
+      const grantedPermissions =
+        '0x000000000000000000000000000000000000000000000000000000000000ff54';
+      const result = checkPermissions(requiredPermissions, grantedPermissions);
+      expect(result).to.be.true;
+    });
+
+    it('should return false when not all multiple literal permissions match granted permissions', async () => {
+      const requiredPermissions = ['CHANGEOWNER', 'CALL'];
+      const grantedPermissions =
+        '0x0000000000000000000000000000000000000000000000000000000000000051';
+      const result = checkPermissions(requiredPermissions, grantedPermissions);
+      expect(result).to.be.false;
+    });
+
+    it('should return true when all multiple literal permissions match granted permissions', async () => {
+      const requiredPermissions = ['CHANGEOWNER', 'CALL'];
+      const grantedPermissions =
+        '0x0000000000000000000000000000000000000000000000000000000000000801';
+      const result = checkPermissions(requiredPermissions, grantedPermissions);
+      expect(result).to.be.true;
+    });
+
+    it('should return false when not all multiple bytes32 permissions match granted permissions', async () => {
+      const requiredPermissions = [
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+        '0x0000000000000000000000000000000000000000000000000000000000000800',
+      ];
+      const grantedPermissions =
+        '0x0000000000000000000000000000000000000000000000000000000000000051';
+      const result = checkPermissions(requiredPermissions, grantedPermissions);
+      expect(result).to.be.false;
+    });
+
+    it('should return false when not all mixed literal and bytes32 permissions match granted permissions', async () => {
+      const requiredPermissions = [
+        'CHANGEOWNER',
+        '0x0000000000000000000000000000000000000000000000000000000000000800',
+      ];
+      const grantedPermissions =
+        '0x0000000000000000000000000000000000000000000000000000000000000051';
+      const result = checkPermissions(requiredPermissions, grantedPermissions);
+      expect(result).to.be.false;
+    });
   });
 });

--- a/src/lib/detector.test.ts
+++ b/src/lib/detector.test.ts
@@ -64,8 +64,40 @@ describe('supportsInterface', () => {
   });
 });
 
-describe('checkPermissions', () => {
+describe.only('checkPermissions', () => {
   describe('test with single permission', () => {
+    it('should throw an error when given an invalid permission string', async () => {
+      const requiredPermissions = 'INVALIDPERMISSION';
+      const grantedPermissions =
+        '0x000000000000000000000000000000000000000000000000000000000000ff51';
+      expect(() =>
+        checkPermissions(requiredPermissions, grantedPermissions),
+      ).to.throw(
+        'Invalid permission string. It must be a valid 32-byte hex string or a known permission name.',
+      );
+    });
+
+    it('should throw an error when given an invalid 32-byte hex string', async () => {
+      const requiredPermissions = '0xinvalidhexstring';
+      const grantedPermissions =
+        '0x000000000000000000000000000000000000000000000000000000000000ff51';
+      expect(() =>
+        checkPermissions(requiredPermissions, grantedPermissions),
+      ).to.throw(
+        'Invalid permission string. It must be a valid 32-byte hex string or a known permission name.',
+      );
+    });
+
+    it('should throw an error when given an invalid grantedPermission 32-byte hex string', async () => {
+      const requiredPermissions = 'CHANGEOWNER';
+      const grantedPermissions = '0xinvalidgrantedpermissionhexstring';
+      expect(() =>
+        checkPermissions(requiredPermissions, grantedPermissions),
+      ).to.throw(
+        'Invalid grantedPermissions string. It must be a valid 32-byte hex string.',
+      );
+    });
+
     it('should return true when single literal permission matches granted permissions', async () => {
       const requiredPermissions = 'CHANGEOWNER';
       const grantedPermissions =
@@ -102,6 +134,28 @@ describe('checkPermissions', () => {
   });
 
   describe('test with multiple permissions', () => {
+    it('should throw an error when given an array containing an invalid permission string', async () => {
+      const requiredPermissions = ['CHANGEOWNER', 'INVALIDPERMISSION'];
+      const grantedPermissions =
+        '0x000000000000000000000000000000000000000000000000000000000000ff51';
+      expect(() =>
+        checkPermissions(requiredPermissions, grantedPermissions),
+      ).to.throw(
+        'Invalid permission string. It must be a valid 32-byte hex string or a known permission name.',
+      );
+    });
+
+    it('should throw an error when given an array containing an invalid 32-byte hex string', async () => {
+      const requiredPermissions = ['CHANGEOWNER', '0xinvalidhexstring'];
+      const grantedPermissions =
+        '0x000000000000000000000000000000000000000000000000000000000000ff51';
+      expect(() =>
+        checkPermissions(requiredPermissions, grantedPermissions),
+      ).to.throw(
+        'Invalid permission string. It must be a valid 32-byte hex string or a known permission name.',
+      );
+    });
+
     it('should return false when one of the literal permissions does not match granted permissions', async () => {
       const requiredPermissions = ['CHANGEPERMISSIONS', 'CALL'];
       const grantedPermissions =

--- a/src/lib/detector.ts
+++ b/src/lib/detector.ts
@@ -57,6 +57,11 @@ export const supportsInterface = async (
   }
 };
 
+/**
+ * @notice Check if the given string is a valid 32-byte hex string.
+ * @param str The string to be checked.
+ * @return A boolean value indicating whether the string is a valid 32-byte hex string.
+ */
 function isValid32ByteHexString(str: string): boolean {
   return (
     str.startsWith('0x') &&
@@ -68,6 +73,12 @@ function isValid32ByteHexString(str: string): boolean {
   );
 }
 
+/**
+ * @notice Map a permission to its corresponding bytes32 representation.
+ * @param permission The permission string to be mapped.
+ * @return The bytes32 representation of the permission.
+ * @dev Throws an error if the input is not a known permission name or a valid 32-byte hex string.
+ */
 function mapPermission(permission: string): string {
   if (
     !LSP6_DEFAULT_PERMISSIONS[permission] &&
@@ -80,6 +91,13 @@ function mapPermission(permission: string): string {
   return LSP6_DEFAULT_PERMISSIONS[permission] || permission;
 }
 
+/**
+ * @notice Check if the required permissions are included in the granted permissions.
+ * @param requiredPermissions An array of required permissions or a single required permission.
+ * @param grantedPermissions The granted permissions as a 32-byte hex string.
+ * @return A boolean value indicating whether the required permissions are included in the granted permissions.
+ * @dev Throws an error if the grantedPermissions input is not a valid 32-byte hex string.
+ */
 export const checkPermissions = (
   requiredPermissions: string[] | string,
   grantedPermissions: string,

--- a/src/lib/detector.ts
+++ b/src/lib/detector.ts
@@ -57,7 +57,26 @@ export const supportsInterface = async (
   }
 };
 
+function isValid32ByteHexString(str: string): boolean {
+  return (
+    str.startsWith('0x') &&
+    str.length === 66 &&
+    str
+      .slice(2)
+      .split('')
+      .every((char) => '0123456789abcdefABCDEF'.includes(char))
+  );
+}
+
 function mapPermission(permission: string): string {
+  if (
+    !LSP6_DEFAULT_PERMISSIONS[permission] &&
+    !isValid32ByteHexString(permission)
+  ) {
+    throw new Error(
+      'Invalid permission string. It must be a valid 32-byte hex string or a known permission name.',
+    );
+  }
   return LSP6_DEFAULT_PERMISSIONS[permission] || permission;
 }
 
@@ -65,6 +84,13 @@ export const checkPermissions = (
   requiredPermissions: string[] | string,
   grantedPermissions: string,
 ): boolean => {
+  // Validate the grantedPermissions string
+  if (!isValid32ByteHexString(grantedPermissions)) {
+    throw new Error(
+      'Invalid grantedPermissions string. It must be a valid 32-byte hex string.',
+    );
+  }
+
   // Convert requiredPermissions to an array if it's a single string
   const requiredPermissionArray: string[] = Array.isArray(requiredPermissions)
     ? requiredPermissions

--- a/src/lib/detector.ts
+++ b/src/lib/detector.ts
@@ -21,6 +21,8 @@
  * @date 2022
  */
 
+import { LSP6_DEFAULT_PERMISSIONS } from '../constants/constants';
+
 import {
   AddressProviderOptions,
   INTERFACE_IDS_0_7_0,
@@ -53,4 +55,33 @@ export const supportsInterface = async (
   } catch (error) {
     throw new Error(`Error checking the interface: ${error}`);
   }
+};
+
+function mapPermission(permission: string): string {
+  return LSP6_DEFAULT_PERMISSIONS[permission] || permission;
+}
+
+export const checkPermissions = (
+  requiredPermissions: string[] | string,
+  grantedPermissions: string,
+): boolean => {
+  // Convert requiredPermissions to an array if it's a single string
+  const requiredPermissionArray: string[] = Array.isArray(requiredPermissions)
+    ? requiredPermissions
+    : [requiredPermissions];
+
+  // Map the literal permissions to their bytes32 representation
+  const mappedPermissionArray: string[] =
+    requiredPermissionArray.map(mapPermission);
+
+  // Perform the AND operation check for each required permission
+  return mappedPermissionArray.every((requiredPermission: string) => {
+    const requiredPermissionBigInt = BigInt(requiredPermission);
+    const grantedPermissionsBigInt = BigInt(grantedPermissions);
+
+    return (
+      (requiredPermissionBigInt & grantedPermissionsBigInt) ===
+      requiredPermissionBigInt
+    );
+  });
 };


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

Introduce a new function described in #285 to allow easy detection of which permission is present, supporting plain bytes32 or literal permissions.

