### PR TITLE
docs: fix missing array square brackets for encodeData

### DIFF
--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -277,9 +277,9 @@ When encoding JSON, it is possible to pass in the JSON object and the URL where 
 
 #### Parameters
 
-##### 1. `data` - Object or array of Objects
+##### 1. `data` - Array of Objects
 
-An object or array of objects containing the following properties:
+An array of objects containing the following properties:
 
 | Name                         | Type                                           | Description                                                                                                                                                      |
 | :--------------------------- | :--------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -358,10 +358,12 @@ myErc725.encodeData([
 ```
 
 ```javascript
-myErc725.encodeData({
-  keyName: 'LSP1UniversalReceiverDelegate',
-  value: '0x1183790f29BE3cDfD0A102862fEA1a4a30b3AdAb',
-});
+myErc725.encodeData([
+  {
+    keyName: 'LSP1UniversalReceiverDelegate',
+    value: '0x1183790f29BE3cDfD0A102862fEA1a4a30b3AdAb',
+  },
+]);
 /**
 {
   keys: ['0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47'],


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

Fix example in library docs where the methode `encodeData` takes an object directly ❌ instead of an array of objects ✅ 

