### PR TITLE
docs: use toggles to display better examples of encoding

### DIFF
--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -322,6 +322,9 @@ After the `data` is encoded, the object is ready to be stored in smart contracts
 
 #### Examples
 
+<details>
+    <summary>Encode a <code>JSONURL</code> with JSON and uploaded URL</summary>
+
 ```javascript title="Encode a JSONURL with JSON and uploaded URL"
 myErc725.encodeData([
   {
@@ -389,6 +392,11 @@ myErc725.encodeData([
 */
 ```
 
+</details>
+
+<details>
+    <summary>Encode a <code>JSONURL</code> with hash function, hash and uploaded URL</summary>
+
 ```javascript title="Encode a JSONURL with hash function, hash and uploaded URL"
 myErc725.encodeData([
   {
@@ -407,6 +415,11 @@ myErc725.encodeData([
 }
 */
 ```
+
+</details>
+
+<details>
+    <summary>Encode dynamic keys</summary>
 
 ```javascript title="Encode dynamic keys"
 const schemas = [
@@ -464,6 +477,11 @@ myErc725.encodeData(
 */
 ```
 
+</details>
+
+<details>
+    <summary>Encode multiple keys at once</summary>
+
 ```javascript title="Encode multiple keys at once"
 myErc725.encodeData([
   {
@@ -505,6 +523,8 @@ myErc725.encodeData([
 }
 */
 ```
+
+</details>
 
 ---
 

--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -53,7 +53,7 @@ An array of extra [LSP-2 ERC725YJSONSchema] objects that can be used to find the
 
 :::
 
-#### Single-Key Example
+### Single-Key Example
 
 ```javascript title="Decoding an object with one key"
 myErc725.decodeData([
@@ -95,7 +95,7 @@ myErc725.decodeData({
 */
 ```
 
-#### Multi-Key Example
+### Multi-Key Example
 
 ```javascript title="Decoding an object with multiple keys"
 myErc725.decodeData([
@@ -146,7 +146,7 @@ myErc725.decodeData([
 */
 ```
 
-#### Dynamic-Key Example
+### Dynamic-Key Example
 
 ```javascript title="Decoding an object with dynamic key and a custom schema"
 const schemas = [
@@ -799,7 +799,7 @@ The name(s) (or the encoded name(s) as schema key) of the element(s) in the smar
 
 :::
 
-#### All-Keys Example
+### All-Keys Example
 
 ```javascript title="Receiving all keys from the schema"
 await myErc725.fetchData();
@@ -840,7 +840,7 @@ await myErc725.fetchData();
 */
 ```
 
-#### Single-Key Example
+### Single-Key Example
 
 ```javascript title="Receiving one key from the schema"
 await myErc725.fetchData('LSP3Profile');
@@ -863,7 +863,7 @@ await myErc725.fetchData(['LSP1UniversalReceiverDelegate']);
 */
 ```
 
-#### Multi-Keys / Dynamic-Keys Example
+### Multi-Keys / Dynamic-Keys Example
 
 ```javascript title="Receiving multiple keys from the schema"
 await myErc725.fetchData(['LSP3Profile', 'LSP1UniversalReceiverDelegate']);
@@ -948,7 +948,7 @@ The name(s) (or the encoded name(s) as schema key) of the element(s) in the smar
 
 :::
 
-#### All-Keys Example
+### All-Keys Example
 
 ```javascript title="Receiving all keys from the schema"
 await myErc725.getData();
@@ -993,7 +993,7 @@ await myErc725.getData();
 */
 ```
 
-#### Single-Key Example
+### Single-Key Example
 
 ```javascript title="Receiving one key from the schema"
 await myErc725.getData('LSP3Profile');
@@ -1034,7 +1034,7 @@ await myErc725.getData('LSP1UniversalReceiverDelegate');
 */
 ```
 
-#### Multi-Key Example
+### Multi-Key Example
 
 ```javascript title="Receiving multiple keys from the schema"
 await myErc725.getData(['LSP3Profile', 'LSP1UniversalReceiverDelegate']);
@@ -1058,7 +1058,7 @@ await myErc725.getData(['LSP3Profile', 'LSP1UniversalReceiverDelegate']);
 */
 ```
 
-#### Dynamic-Key Example
+### Dynamic-Key Example
 
 ```javascript title="Receiving dynamic keys from the schema"
 await myErc725.getData({
@@ -1190,7 +1190,7 @@ An array of extra [LSP-2 ERC725YJSONSchema] objects that can be used to find the
 | `result` | Record string    | If the parameter `keys` is a string[&nbsp;] and the schema was found. |
 | `result` | null             | If the schema was not found.                                          |
 
-#### Example using a predefined LSP3 schema
+### Example using a predefined LSP3 schema
 
 ```javascript title="Parsing the hashed key from the LSP3 schema"
 myErc725.getSchema(
@@ -1229,7 +1229,7 @@ myErc725.getSchema([
 */
 ```
 
-#### Example using a custom schema
+### Example using a custom schema
 
 ```javascript title="Parsing the hashed key from a custom schema"
 myErc725.getSchema(


### PR DESCRIPTION
In the docs, all the examples are one after the other, making the code snippets very long and big.

- Sort them between toggles that can be opened, so that it is easier to find the relevant example for the developer.
- Improve subheadings so that examples can be more easily found from the sidebar

![Screenshot 2023-07-31 at 16 35 51](https://github.com/ERC725Alliance/erc725.js/assets/31145285/b9c12a71-a492-4823-b26c-414f811e2355)

![image](https://github.com/ERC725Alliance/erc725.js/assets/31145285/d9e40506-f9a6-43c6-81b6-3eceef2771c2)
