### PR TITLE
chore: use web3-utils instead of bignumber.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.17.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "bignumber.js": "^9.1.1",
         "ethereumjs-util": "^7.1.5",
         "web3-eth-abi": "^1.10.0",
         "web3-providers-http": "^1.10.0",
@@ -1930,6 +1929,7 @@
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
       "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -12260,7 +12260,8 @@
     "bignumber.js": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
-      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig=="
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+      "dev": true
     },
     "binary-extensions": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "web3": "^1.10.0"
   },
   "dependencies": {
-    "bignumber.js": "^9.1.1",
     "ethereumjs-util": "^7.1.5",
     "web3-eth-abi": "^1.10.0",
     "web3-providers-http": "^1.10.0",

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -18,7 +18,7 @@
  * @author Hugo Masclet <@Hugoo>
  * @author Callum Grindle <@CallumGrindle>
  * @author Jean Cavallera <@CJ42>
- * @date 2020
+ * @date 2023
  */
 
 /*
@@ -41,9 +41,8 @@ import {
   hexToBytes,
   bytesToHex,
   toHex,
+  toBN,
 } from 'web3-utils';
-
-import BigNumber from 'bignumber.js';
 
 import { JSONURLDataToEncode, URLDataWithHash } from '../types';
 import { AssetURLEncode } from '../types/encodeData';
@@ -403,7 +402,7 @@ const valueTypeEncodingMap = {
         );
       }
 
-      return BigNumber(value).toNumber();
+      return toBN(value).toNumber();
     },
   },
   uint256: {
@@ -423,7 +422,7 @@ const valueTypeEncodingMap = {
         );
       }
 
-      return BigNumber(value).toNumber();
+      return toBN(value).toNumber();
     },
   },
   bytes32: {


### PR DESCRIPTION
Let's save [18.2kb](https://bundlephobia.com/package/bignumber.js@9.1.1) as this feature is already included in [web3-utils](https://web3js.readthedocs.io/en/v1.2.11/web3-utils.html#bn)

<img width="543" alt="image" src="https://github.com/ERC725Alliance/erc725.js/assets/477945/3e649498-2061-4eec-b4be-f193f7219424">
