### PR TITLE
refactor: expose `checkPermissions` function

### DIFF
--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -4,6 +4,83 @@ sidebar_position: 1
 
 # ERC725
 
+## checkPermissions
+
+```js
+myErc725.checkPermissions(requiredPermissions, grantedPermissions);
+```
+
+```js
+ERC725.checkPermissions(requiredPermissions, grantedPermissions);
+```
+
+Check if the required permissions are included in the granted permissions as defined by the [LSP6 KeyManager Standard](https://docs.lukso.tech/standards/universal-profile/lsp6-key-manager).
+
+:::info
+
+`checkPermissions` is available as either a static or non-static method so can be called without instantiating an ERC725 object.
+
+:::
+
+#### Parameters
+
+##### 1. `requiredPermissions` - String[] | String
+
+An array of required permissions or a single required permission. (32bytes hex or the official name of the permission).
+
+##### 2. `grantedPermissions` - String
+
+The granted permissions. (32bytes hex).
+
+#### Returns
+
+| Type    | Description                                                                                                                                      |
+| :------ | :----------------------------------------------------------------------------------------------------------------------------------------------- |
+| boolean | A boolean value indicating whether the required permissions are included in the granted permissions as defined by the [LSP6 KeyManager Standard] |
+
+#### Permission-Name Example
+
+```javascript title="Checking permissions by name"
+const requiredPermissions = 'CHANGEOWNER';
+const grantedPermissions =
+  '0x000000000000000000000000000000000000000000000000000000000000ff51';
+ERC725.checkPermissions(requiredPermissions, grantedPermissions);
+// true
+
+// This method is also available on the instance:
+
+const requiredPermissions = ['CHANGEOWNER', 'CALL'];
+const grantedPermissions =
+  '0x0000000000000000000000000000000000000000000000000000000000000051';
+myErc725.checkPermissions(requiredPermissions, grantedPermissions);
+// false
+```
+
+#### 32bytes hex Example
+
+```javascript title="Checking permissions by 32bytes hex"
+const requiredPermissions = [
+  '0x0000000000000000000000000000000000000000000000000000000000000001',
+  '0x0000000000000000000000000000000000000000000000000000000000000800',
+];
+const grantedPermissions =
+  '0x0000000000000000000000000000000000000000000000000000000000000051';
+
+ERC725.checkPermissions(requiredPermissions, grantedPermissions);
+// false
+
+// This method is also available on the instance:
+
+const requiredPermissions =
+  '0x0000000000000000000000000000000000000000000000000000000000000001';
+const grantedPermissions =
+  '0x0000000000000000000000000000000000000000000000000000000000000051';
+
+myErc725.checkPermissions(requiredPermissions, grantedPermissions);
+// true
+```
+
+---
 ## decodeData
 
 ```js

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1414,6 +1414,45 @@ describe('supportsInterface', () => {
   // TODO: add test to test the actual behavior of the function.
 });
 
+describe('checkPermissions', () => {
+  const erc725Instance = new ERC725([]);
+
+  it('is available on instance', () => {
+    chaiAssert.typeOf(erc725Instance.checkPermissions, 'function');
+
+    const requiredPermissions = [
+      '0x0000000000000000000000000000000000000000000000000000000000000004',
+      '0x0000000000000000000000000000000000000000000000000000000000000800',
+    ];
+    const grantedPermissions =
+      '0x000000000000000000000000000000000000000000000000000000000000ff51';
+    const result = erc725Instance.checkPermissions(
+      requiredPermissions,
+      grantedPermissions,
+    );
+
+    assert.equal(result, false);
+  });
+
+  it('is available on class', () => {
+    chaiAssert.typeOf(ERC725.checkPermissions, 'function');
+
+    const requiredPermissions = [
+      '0x0000000000000000000000000000000000000000000000000000000000000004',
+      '0x0000000000000000000000000000000000000000000000000000000000000800',
+    ];
+    const grantedPermissions =
+      '0x000000000000000000000000000000000000000000000000000000000000ff51';
+
+    const result = ERC725.checkPermissions(
+      requiredPermissions,
+      grantedPermissions,
+    );
+
+    assert.equal(result, false);
+  });
+});
+
 describe('decodeMappingKey', () => {
   const erc725Instance = new ERC725([]);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ import { decodeData } from './lib/decodeData';
 import { getDataFromExternalSources } from './lib/getDataFromExternalSources';
 import { DynamicKeyPart, DynamicKeyParts } from './types/dynamicKeys';
 import { getData } from './lib/getData';
-import { supportsInterface } from './lib/detector';
+import { supportsInterface, checkPermissions } from './lib/detector';
 import { decodeMappingKey } from './lib/decodeMappingKey';
 
 /* eslint-disable-next-line */
@@ -612,6 +612,36 @@ export class ERC725 {
       address: options.address,
       provider: this.initializeProvider(options.rpcUrl),
     });
+  }
+
+  /**
+   * Check if the required permissions are included in the granted permissions as defined by the LSP6 KeyManager Standard.
+   *
+   * @link https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-6-KeyManager.md LSP6 KeyManager Standard.
+   * @param requiredPermissions An array of required permissions or a single required permission.
+   * @param grantedPermissions The granted permissions as a 32-byte hex string.
+   * @return A boolean value indicating whether the required permissions are included in the granted permissions.
+   */
+  static checkPermissions(
+    requiredPermissions: string[] | string,
+    grantedPermissions: string,
+  ): boolean {
+    return checkPermissions(requiredPermissions, grantedPermissions);
+  }
+
+  /**
+   * Check if the required permissions are included in the granted permissions as defined by the LSP6 KeyManager Standard.
+   *
+   * @link https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-6-KeyManager.md LSP6 KeyManager Standard.
+   * @param requiredPermissions An array of required permissions or a single required permission.
+   * @param grantedPermissions The granted permissions as a 32-byte hex string.
+   * @return A boolean value indicating whether the required permissions are included in the granted permissions.
+   */
+  checkPermissions(
+    requiredPermissions: string[] | string,
+    grantedPermissions: string,
+  ): boolean {
+    return ERC725.checkPermissions(requiredPermissions, grantedPermissions);
   }
 }
 


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

- refactor: expose `checkPermissions` function
- docs: add code example for `checkPermissions` function
- test: check if the function is exposed correctly on the instance and the class

### What is the current behaviour (you can also link to an open issue here)?

PR related is: https://github.com/ERC725Alliance/erc725.js/pull/286/

### What is the new behaviour (if this is a feature change)?

Exposing the checkPermissions function

### Other information:

Links:
PR: https://github.com/ERC725Alliance/erc725.js/pull/286/
Original issue: https://github.com/ERC725Alliance/erc725.js/issues/285
