### PR TITLE
refactor!: change LSP3 to SupportedStandards:LSP3Profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ If you install it on the backend side, you may need to also install [`isomorphic
 import { ERC725 } from '@erc725/erc725.js';
 import Web3 from 'web3';
 
-// Part of LSP3-UniversalProfile Schema
-// https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-3-UniversalProfile.md
+// Part of LSP3-Profile Schema
+// https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-3-Profile-Metadata.md
 const schema = [
   {
-    name: 'SupportedStandards:LSP3UniversalProfile',
-    key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
+    name: 'SupportedStandards:LSP3Profile',
+    key: '0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347',
     keyType: 'Mapping',
-    valueContent: '0xabe425d6',
+    valueContent: '0x5ef83ad9',
     valueType: 'bytes',
   },
   {
@@ -89,9 +89,9 @@ await myErc725.getData();
 /**
 [
   {
-    name: 'SupportedStandards:LSP3UniversalProfile',
-    key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
-    value: '0xabe425d6',
+    name: 'SupportedStandards:LSP3Profile',
+    key: '0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347',
+    value: '0x5ef83ad9',
   },
   {
     name: 'LSP1UniversalReceiverDelegate',
@@ -130,9 +130,9 @@ await myErc725.fetchData();
 /**
 [
   {
-    name: 'SupportedStandards:LSP3UniversalProfile',
-    key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
-    value: '0xabe425d6'
+    name: 'SupportedStandards:LSP3Profile',
+    key: '0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347',
+    value: '0x5ef83ad9'
   },
   {
     name: 'LSP3Profile',

--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -643,8 +643,8 @@ The hash must be retrievable from the ERC725Y contract via the [getData](#getdat
 ERC725.encodeKeyName('LSP3Profile');
 // '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5'
 
-ERC725.encodeKeyName('SupportedStandards:LSP3UniversalProfile');
-// '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38'
+ERC725.encodeKeyName('SupportedStandards:LSP3Profile');
+// '0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347'
 
 ERC725.encodeKeyName(
   'AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe',
@@ -883,9 +883,9 @@ await myErc725.fetchData();
 /**
 [
   {
-    name: 'SupportedStandards:LSP3UniversalProfile',
-    key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
-    value: '0xabe425d6'
+    name: 'SupportedStandards:LSP3Profile',
+    key: '0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347',
+    value: '0x5ef83ad9'
   },
   {
     name: 'LSP3Profile',
@@ -1032,9 +1032,9 @@ await myErc725.getData();
 /**
 [
   {
-    name: 'SupportedStandards:LSP3UniversalProfile',
-    key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
-    value: '0xabe425d6',
+    name: 'SupportedStandards:LSP3Profile',
+    key: '0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347',
+    value: '0x5ef83ad9',
   },
   {
     name: 'LSP1UniversalReceiverDelegate',

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,11 +35,11 @@ import Web3 from 'web3';
 // https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-3-UniversalProfile.md
 const schemas = [
   {
-    name: 'SupportedStandards:LSP3UniversalProfile',
-    key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
+    name: 'SupportedStandards:LSP3Profile',
+    key: '0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347',
     keyType: 'Mapping',
     valueType: 'bytes',
-    valueContent: '0xabe425d6',
+    valueContent: '0x5ef83ad9',
   },
   {
     name: 'LSP3Profile',
@@ -72,16 +72,16 @@ const erc725 = new ERC725(schemas, address, RPC_URL, config);
 await erc725.getOwner();
 // > '0x28D25E70819140daF65b724158D00c373D1a18ee'
 
-await erc725.getData('SupportedStandards:LSP3UniversalProfile');
+await erc725.getData('SupportedStandards:LSP3Profile');
 /**
 {
-  'SupportedStandards:LSP3UniversalProfile': '0xabe425d6'
+  'SupportedStandards:LSP3Profile': '0x5ef83ad9'
 }
 */
 
 await erc725.getData([
   'LSP3Profile',
-  'SupportedStandards:LSP3UniversalProfile',
+  'SupportedStandards:LSP3Profile',
 ]);
 /**
 {
@@ -90,7 +90,7 @@ await erc725.getData([
     hash: '0xb4f9d72e83bbe7e250ed9ec80332c493b7b3d73e0d72f7b2c7ab01c39216eb1a',
     hashFunction: 'keccak256(utf8)'
   },
-  'SupportedStandards:LSP3UniversalProfile': '0xabe425d6'
+  'SupportedStandards:LSP3Profile': '0x5ef83ad9'
 }
 */
 

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -26,7 +26,7 @@ Current provided LSPs are:
 
 ```
 LSP1UniversalReceiverDelegate.json
-LSP3UniversalProfileMetadata.json
+LSP3ProfileMetadata.json
 LSP4DigitalAssetLegacy.json
 LSP4DigitalAsset.json
 LSP5ReceivedAssets.json
@@ -39,7 +39,7 @@ LSP12IssuedAssets.json
 You can import them from:
 
 ```js
-import LSP3 from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json';
+import LSP3 from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';
 import LSP5 from '@erc725/erc725.js/schemas/LSP5ReceivedAssets.json';
 // ...
 

--- a/examples/src/fetchData.js
+++ b/examples/src/fetchData.js
@@ -8,8 +8,8 @@ const dataAllKeys = await myERC725.fetchData();
 /**
 [
   {
-    key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
-    name: 'SupportedStandards:LSP3UniversalProfile',
+    key: '0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347',
+    name: 'SupportedStandards:LSP3Profile',
     value: false
   },
   {

--- a/examples/src/instantiation.js
+++ b/examples/src/instantiation.js
@@ -11,10 +11,10 @@ const IPFS_GATEWAY = 'https://2eff.lukso.dev/ipfs/';
 export function getInstance() {
   const schema = [
     {
-      name: 'SupportedStandards:LSP3UniversalProfile',
-      key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
+      name: 'SupportedStandards:LSP3Profile',
+      key: '0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347',
       keyType: 'Mapping',
-      valueContent: '0xabe425d6',
+      valueContent: '0x5ef83ad9',
       valueType: 'bytes',
     },
     {

--- a/schemas/LSP3ProfileMetadata.json
+++ b/schemas/LSP3ProfileMetadata.json
@@ -1,10 +1,10 @@
 [
   {
-    "name": "SupportedStandards:LSP3UniversalProfile",
-    "key": "0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38",
+    "name": "SupportedStandards:LSP3Profile",
+    "key": "0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347",
     "keyType": "Mapping",
     "valueType": "bytes4",
-    "valueContent": "0xabe425d6"
+    "valueContent": "0x5ef83ad9"
   },
   {
     "name": "LSP3Profile",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -446,9 +446,9 @@ describe('Running @erc725/erc725.js tests...', () => {
                 '0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000141098603b193d276f5fa176cc02007b609f9dae6b000000000000000000000000',
             },
             {
-              key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38', // SupportedStandards:LSP3UniversalProfile
+              key: '0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347', // SupportedStandards:LSP3Profile
               value:
-                '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000004abe425d600000000000000000000000000000000000000000000000000000000',
+                '0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000045ef83ad900000000000000000000000000000000000000000000000000000000',
             },
           ],
         },
@@ -464,10 +464,10 @@ describe('Running @erc725/erc725.js tests...', () => {
             valueType: 'bytes',
           },
           {
-            name: 'SupportedStandards:LSP3UniversalProfile',
-            key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
+            name: 'SupportedStandards:LSP3Profile',
+            key: '0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347',
             keyType: 'Mapping',
-            valueContent: '0xabe425d6',
+            valueContent: '0x5ef83ad9',
             valueType: 'bytes',
           },
           {
@@ -488,7 +488,7 @@ describe('Running @erc725/erc725.js tests...', () => {
           keyName: 'LSP12IssuedAssetsMap:<address>',
           dynamicKeyParts: '0xb74a88C43BCf691bd7A851f6603cb1868f6fc147',
         },
-        'SupportedStandards:LSP3UniversalProfile',
+        'SupportedStandards:LSP3Profile',
       ]);
       assert.deepStrictEqual(data, [
         {
@@ -502,9 +502,9 @@ describe('Running @erc725/erc725.js tests...', () => {
           value: '0x1098603B193d276f5fA176CC02007B609F9DAE6b',
         },
         {
-          key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
-          name: 'SupportedStandards:LSP3UniversalProfile',
-          value: '0xabe425d6',
+          key: '0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347',
+          name: 'SupportedStandards:LSP3Profile',
+          value: '0x5ef83ad9',
         },
       ]);
     });

--- a/src/lib/encodeKeyName.test.ts
+++ b/src/lib/encodeKeyName.test.ts
@@ -43,9 +43,9 @@ describe('encodeKeyName', () => {
         '0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0',
     },
     {
-      keyName: 'SupportedStandards:LSP3UniversalProfile',
+      keyName: 'SupportedStandards:LSP3Profile',
       expectedKey:
-        '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
+        '0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347',
     },
     {
       keyName: 'MyCoolAddress:0xcafecafecafecafecafecafecafecafecafecafe',

--- a/src/lib/schemaParser.test.ts
+++ b/src/lib/schemaParser.test.ts
@@ -83,14 +83,14 @@ describe('schemaParser getSchema', () => {
   describe('Mapping', () => {
     it('finds known mappings', () => {
       const schema = getSchema(
-        '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
+        '0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347',
       );
 
       assert.deepStrictEqual(schema, {
-        name: 'SupportedStandards:LSP3UniversalProfile',
-        key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
+        name: 'SupportedStandards:LSP3Profile',
+        key: '0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347',
         keyType: 'Mapping',
-        valueContent: '0xabe425d6',
+        valueContent: '0x5ef83ad9',
         valueType: 'bytes4',
       });
     });

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -689,7 +689,7 @@ describe('utils', () => {
       },
       {
         keyType: 'Mapping',
-        keyName: 'SupportedStandards:LSP3UniversalProfile',
+        keyName: 'SupportedStandards:LSP3Profile',
       },
       {
         keyType: 'Mapping',

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,14 +1,14 @@
 import { ERC725JSONSchema } from '../types/ERC725JSONSchema';
 
 import LSP1UniversalReceiverDelegate from '../../schemas/LSP1UniversalReceiverDelegate.json';
-import LSP3UniversalProfile from '../../schemas/LSP3UniversalProfileMetadata.json';
+import LSP3Profile from '../../schemas/LSP3ProfileMetadata.json';
 import LSP4DigitalAssetLegacy from '../../schemas/LSP4DigitalAssetLegacy.json';
 import LSP4DigitalAsset from '../../schemas/LSP4DigitalAsset.json';
 import LSP5ReceivedAssets from '../../schemas/LSP5ReceivedAssets.json';
 import LSP6KeyManager from '../../schemas/LSP6KeyManager.json';
 
 export default LSP1UniversalReceiverDelegate.concat(
-  LSP3UniversalProfile,
+  LSP3Profile,
   LSP4DigitalAssetLegacy,
   LSP4DigitalAsset,
   LSP5ReceivedAssets,

--- a/test/mockSchema.ts
+++ b/test/mockSchema.ts
@@ -17,16 +17,16 @@ export const mockSchema: (ERC725JSONSchema & {
 })[] = [
   // Case 1
   {
-    name: 'SupportedStandards:LSP3UniversalProfile',
-    key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
+    name: 'SupportedStandards:LSP3Profile',
+    key: '0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347',
     keyType: 'Mapping',
-    valueContent: '0xabe425d6',
+    valueContent: '0x5ef83ad9',
     valueType: 'bytes',
     // Testing data
-    returnRawData: abiCoder.encodeParameter('bytes', '0xabe425d6'),
-    returnRawDataArray: abiCoder.encodeParameter('bytes[]', ['0xabe425d6']),
-    returnGraphData: '0xabe425d6',
-    expectedResult: '0xabe425d6',
+    returnRawData: abiCoder.encodeParameter('bytes', '0x5ef83ad9'),
+    returnRawDataArray: abiCoder.encodeParameter('bytes[]', ['0x5ef83ad9']),
+    returnGraphData: '0x5ef83ad9',
+    expectedResult: '0x5ef83ad9',
   },
 
   // Case 2
@@ -571,25 +571,25 @@ export const mockSchema: (ERC725JSONSchema & {
     name: 'MyCoolAddress:0xcafecafecafecafecafecafecafecafecafecafe',
     key: '0x22496f48a493035f0ab40000cafecafecafecafecafecafecafecafecafecafe',
     keyType: 'Mapping',
-    valueContent: '0xabe425d6',
+    valueContent: '0x5ef83ad9',
     valueType: 'bytes',
     // Testing data
-    returnRawData: abiCoder.encodeParameter('bytes', '0xabe425d6'),
-    returnRawDataArray: abiCoder.encodeParameter('bytes[]', ['0xabe425d6']),
-    returnGraphData: '0xabe425d6',
-    expectedResult: '0xabe425d6',
+    returnRawData: abiCoder.encodeParameter('bytes', '0x5ef83ad9'),
+    returnRawDataArray: abiCoder.encodeParameter('bytes[]', ['0x5ef83ad9']),
+    returnGraphData: '0x5ef83ad9',
+    expectedResult: '0x5ef83ad9',
   },
   {
     name: 'AddressPermissions:Permissions:cafecafecafecafecafecafecafecafecafecafe',
     key: '0x4b80742de2bf82acb3630000cafecafecafecafecafecafecafecafecafecafe',
     keyType: 'MappingWithGrouping',
-    valueContent: '0xabe425d6',
+    valueContent: '0x5ef83ad9',
     valueType: 'bytes',
     // Testing data
-    returnRawData: abiCoder.encodeParameter('bytes', '0xabe425d6'),
-    returnRawDataArray: abiCoder.encodeParameter('bytes[]', ['0xabe425d6']),
-    returnGraphData: '0xabe425d6',
-    expectedResult: '0xabe425d6',
+    returnRawData: abiCoder.encodeParameter('bytes', '0x5ef83ad9'),
+    returnRawDataArray: abiCoder.encodeParameter('bytes[]', ['0x5ef83ad9']),
+    returnGraphData: '0x5ef83ad9',
+    expectedResult: '0x5ef83ad9',
   },
   {
     name: 'Hello:<address>',


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

- Change `SupportedStandards:LSP3UniversalProfile` to `SupportedStandards:LSP3Profile`:
    - Change KeyName
   - Change Key
   - Change valueContent
   
- Change the name of the JSON to `LSP3ProfileMetadata.json`

### Other information:

Check here for context: https://github.com/lukso-network/LIPs/pull/220

Do not release until lsp-smart-contract is released 
