### PR TITLE
fix: Remove hardcoded require statement inside of module (esm) code.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@
  */
 
 import { hexToNumber, isAddress, leftPad, toHex } from 'web3-utils';
+import HttpProvider from 'web3-providers-http';
 
 import { ProviderWrapper } from './provider/providerWrapper';
 
@@ -61,9 +62,6 @@ import { DynamicKeyPart, DynamicKeyParts } from './types/dynamicKeys';
 import { getData } from './lib/getData';
 import { supportsInterface, checkPermissions } from './lib/detector';
 import { decodeMappingKey } from './lib/decodeMappingKey';
-
-/* eslint-disable-next-line */
-const HttpProvider = require('web3-providers-http');
 
 export {
   ERC725JSONSchema,


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

There was a

```js
/* eslint-disable-next-line */
const HttpProvider = require("web3-providers-http");
```

in the code which is illegal in a esm module.

### What is the current behaviour (you can also link to an open issue here)?

When using a true esm compiler like esbuild or bun the require function will no longer be defined
in the esm (module) context.

### What is the new behaviour (if this is a feature change)?

It will work in cjs and esm

### Other information:

https://app.clickup.com/t/2645698/DEV-8268
