### PR TITLE
fix: incorrect value in schema for array length in `...Map`

### DIFF
--- a/schemas/LSP10ReceivedVaults.json
+++ b/schemas/LSP10ReceivedVaults.json
@@ -3,7 +3,7 @@
     "name": "LSP10VaultsMap:<address>",
     "key": "0x192448c3c0f88c7f238c0000<address>",
     "keyType": "Mapping",
-    "valueType": "(bytes4,bytes8)",
+    "valueType": "(bytes4,uint128)",
     "valueContent": "(Bytes4,Number)"
   },
   {

--- a/schemas/LSP12IssuedAssets.json
+++ b/schemas/LSP12IssuedAssets.json
@@ -10,7 +10,7 @@
     "name": "LSP12IssuedAssetsMap:<address>",
     "key": "0x74ac2555c10b9349e78f0000<address>",
     "keyType": "Mapping",
-    "valueType": "(bytes4,bytes8)",
+    "valueType": "(bytes4,uint128)",
     "valueContent": "(Bytes4,Number)"
   }
 ]

--- a/schemas/LSP3ProfileMetadata.json
+++ b/schemas/LSP3ProfileMetadata.json
@@ -24,7 +24,7 @@
     "name": "LSP12IssuedAssetsMap:<address>",
     "key": "0x74ac2555c10b9349e78f0000<address>",
     "keyType": "Mapping",
-    "valueType": "(bytes4,bytes8)",
+    "valueType": "(bytes4,uint128)",
     "valueContent": "(Bytes4,Number)"
   },
   {
@@ -38,7 +38,7 @@
     "name": "LSP5ReceivedAssetsMap:<address>",
     "key": "0x812c4334633eb816c80d0000<address>",
     "keyType": "Mapping",
-    "valueType": "(bytes4,bytes8)",
+    "valueType": "(bytes4,uint128)",
     "valueContent": "(Bytes4,Number)"
   },
   {

--- a/schemas/LSP4DigitalAsset.json
+++ b/schemas/LSP4DigitalAsset.json
@@ -38,7 +38,7 @@
     "name": "LSP4CreatorsMap:<address>",
     "key": "0x6de85eaf5d982b4e5da00000<address>",
     "keyType": "Mapping",
-    "valueType": "(bytes4,bytes8)",
+    "valueType": "(bytes4,uint128)",
     "valueContent": "(Bytes4,Number)"
   }
 ]

--- a/schemas/LSP5ReceivedAssets.json
+++ b/schemas/LSP5ReceivedAssets.json
@@ -10,7 +10,7 @@
     "name": "LSP5ReceivedAssetsMap:<address>",
     "key": "0x812c4334633eb816c80d0000<address>",
     "keyType": "Mapping",
-    "valueType": "(bytes4,bytes8)",
+    "valueType": "(bytes4,uint128)",
     "valueContent": "(Bytes4,Number)"
   }
 ]


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

🐜 Bug Fix

### What is the current behaviour (you can also link to an open issue here)?

The schemas for the `...Map` value in the tuple mention `bytes8`. But this was changed to `uint128`.

See following PRs in LIP repos for reference:

- https://github.com/lukso-network/LIPs/pull/173
- https://github.com/lukso-network/LIPs/pull/233

### What is the new behaviour (if this is a feature change)?

Correct the schemas with the right value type in the tuple.