### PR TITLE
feat: add schemas for LSP8 + LSP17

### DIFF
--- a/schemas/LSP17ContractExtension.json
+++ b/schemas/LSP17ContractExtension.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "LSP17Extension:<bytes4>",
+    "key": "0xcee78b4094da860110960000<bytes4>",
+    "keyType": "Mapping",
+    "valueType": "address",
+    "valueContent": "Address"
+  }
+]

--- a/schemas/LSP8IdentifiableDigitalAsset.json
+++ b/schemas/LSP8IdentifiableDigitalAsset.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "LSP8TokenIdType",
+    "key": "0x715f248956de7ce65e94d9d836bfead479f7e70d69b718d47bfe7b00e05b4fe4",
+    "keyType": "Singleton",
+    "valueType": "uint256",
+    "valueContent": "Number"
+  },
+  {
+    "name": "LSP8MetadataTokenURI:<address|uint256|bytes32|string>",
+    "key": "0x4690256ef7e93288012f0000<address|uint256|bytes32|string>",
+    "keyType": "Mapping",
+    "valueType": "(bytes4,string)",
+    "valueContent": "(Bytes4,URI)"
+  },
+  {
+    "name": "LSP8TokenMetadataBaseURI",
+    "key": "0x1a7628600c3bac7101f53697f48df381ddc36b9015e7d7c9c5633d1252aa2843",
+    "keyType": "Singleton",
+    "valueType": "(bytes4,string)",
+    "valueContent": "(Bytes4,URI)"
+  },
+  {
+    "name": "LSP8ReferenceContract",
+    "key": "0x708e7b881795f2e6b6c2752108c177ec89248458de3bf69d0d43480b3e5034e6",
+    "keyType": "Singleton",
+    "valueType": "(address,bytes32)",
+    "valueContent": "(Address,bytes32)"
+  }
+]


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

feature

### What is the current behaviour (you can also link to an open issue here)?

There is no schemas for LSP8

### What is the new behaviour (if this is a feature change)?

Create `LSP8IdentifiableDigitalAsset.json` file with all the ERC725Y data keys of LSP8.
Also created a single file for the LSP17 data key (although it is also present in LSP3 json schema file).
