### PR TITLE
fix: update lsp6 schema

### DIFF
--- a/schemas/LSP6KeyManager.json
+++ b/schemas/LSP6KeyManager.json
@@ -17,8 +17,8 @@
     "name": "AddressPermissions:AllowedCalls:<address>",
     "key": "0x4b80742de2bf393a64c70000<address>",
     "keyType": "MappingWithGrouping",
-    "valueType": "(bytes4,address,bytes4)[CompactBytesArray]",
-    "valueContent": "(Bytes4,Address,Bytes4)"
+    "valueType": "(bytes4,address,bytes4,bytes4)[CompactBytesArray]",
+    "valueContent": "(BitArray,Address,Bytes4,Bytes4)"
   },
   {
     "name": "AddressPermissions:AllowedERC725YDataKeys:<address>",


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
FIx: Update LSP6 schema valueType and valueContent

### What is the current behaviour (you can also link to an open issue here)?

### What is the new behaviour (if this is a feature change)?

### Other information:
