### PR TITLE
feat: add more schemas available to parse via `getSchema`

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -6,6 +6,11 @@ import LSP4DigitalAssetLegacy from '../../schemas/LSP4DigitalAssetLegacy.json';
 import LSP4DigitalAsset from '../../schemas/LSP4DigitalAsset.json';
 import LSP5ReceivedAssets from '../../schemas/LSP5ReceivedAssets.json';
 import LSP6KeyManager from '../../schemas/LSP6KeyManager.json';
+import LSP8IdentifiableDigitalAsset from '../../schemas/LSP8IdentifiableDigitalAsset.json';
+import LSP9Vault from '../../schemas/LSP9Vault.json';
+import LSP10ReceivedVaults from '../../schemas/LSP10ReceivedVaults.json';
+import LSP12IssuedAssets from '../../schemas/LSP12IssuedAssets.json';
+import LSP17ContractExtension from '../../schemas/LSP17ContractExtension.json';
 
 export default LSP1UniversalReceiverDelegate.concat(
   LSP3Profile,
@@ -13,4 +18,9 @@ export default LSP1UniversalReceiverDelegate.concat(
   LSP4DigitalAsset,
   LSP5ReceivedAssets,
   LSP6KeyManager,
+  LSP8IdentifiableDigitalAsset,
+  LSP9Vault,
+  LSP10ReceivedVaults,
+  LSP12IssuedAssets,
+  LSP17ContractExtension,
 ) as ERC725JSONSchema[];


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

**Feature**

### What is the current behaviour (you can also link to an open issue here)?

The function `getSchema` function can only parse data keys defined up to LSP6, not all the schemas defined under the `schemas/` folder.

### What is the new behaviour (if this is a feature change)?

Make the schemas for LSP8, LSP9, LSP17, etc... available to parse in the `getSchema` function.

### Other information:
