### PR TITLE
feat: add support to encode / decode any `uint8` to `uint256` types

### DIFF
--- a/src/lib/decodeData.ts
+++ b/src/lib/decodeData.ts
@@ -53,9 +53,6 @@ const isValidTupleDefinition = (tupleContent: string): boolean => {
 const extractTupleElements = (tupleContent: string): string[] =>
   tupleContent.substring(1, tupleContent.length - 1).split(',');
 
-const extractTupleElements = (tupleContent: string): string[] =>
-  tupleContent.substring(1, tupleContent.length - 1).split(',');
-
 export const isValidTuple = (valueType: string, valueContent: string) => {
   if (
     !isValidTupleDefinition(valueType) ||

--- a/src/lib/decodeData.ts
+++ b/src/lib/decodeData.ts
@@ -50,17 +50,8 @@ const isValidTupleDefinition = (tupleContent: string): boolean => {
   return true;
 };
 
-const extractValueTypesFromTuple = (tupleContent: string): string[] => {
-  let valueTypeToDecode = tupleContent;
-
-  if (tupleContent.includes(COMPACT_BYTES_ARRAY_STRING)) {
-    valueTypeToDecode = tupleContent.replace(COMPACT_BYTES_ARRAY_STRING, '');
-  }
-
-  return valueTypeToDecode
-    .substring(1, valueTypeToDecode.length - 1)
-    .split(',');
-};
+const extractTupleElements = (tupleContent: string): string[] =>
+  tupleContent.substring(1, tupleContent.length - 1).split(',');
 
 const extractTupleElements = (tupleContent: string): string[] =>
   tupleContent.substring(1, tupleContent.length - 1).split(',');
@@ -148,11 +139,11 @@ export const decodeTupleKeyValue = (
 ): Array<string> => {
   // We assume data has already been validated at this stage
 
-  const valueTypeParts = extractValueTypesFromTuple(valueType);
+  // Sanitize the string to keep only the tuple, if we are dealing with `CompactBytesArray`
+  const valueTypeToDecode = valueType.replace(COMPACT_BYTES_ARRAY_STRING, '');
 
-  const valueContentParts = valueContent
-    .substring(1, valueContent.length - 1)
-    .split(',');
+  const valueTypeParts = extractTupleElements(valueTypeToDecode);
+  const valueContentParts = extractTupleElements(valueContent);
 
   const bytesLengths: number[] = [];
 

--- a/src/lib/decodeData.ts
+++ b/src/lib/decodeData.ts
@@ -50,6 +50,18 @@ const isValidTupleDefinition = (tupleContent: string): boolean => {
   return true;
 };
 
+const extractValueTypesFromTuple = (tupleContent: string): string[] => {
+  let valueTypeToDecode = tupleContent;
+
+  if (tupleContent.includes(COMPACT_BYTES_ARRAY_STRING)) {
+    valueTypeToDecode = tupleContent.replace(COMPACT_BYTES_ARRAY_STRING, '');
+  }
+
+  return valueTypeToDecode
+    .substring(1, valueTypeToDecode.length - 1)
+    .split(',');
+};
+
 const extractTupleElements = (tupleContent: string): string[] =>
   tupleContent.substring(1, tupleContent.length - 1).split(',');
 
@@ -136,11 +148,11 @@ export const decodeTupleKeyValue = (
 ): Array<string> => {
   // We assume data has already been validated at this stage
 
-  // Sanitize the string to keep only the tuple, if we are dealing with `CompactBytesArray`
-  const valueTypeToDecode = valueType.replace(COMPACT_BYTES_ARRAY_STRING, '');
+  const valueTypeParts = extractValueTypesFromTuple(valueType);
 
-  const valueTypeParts = extractTupleElements(valueTypeToDecode);
-  const valueContentParts = extractTupleElements(valueContent);
+  const valueContentParts = valueContent
+    .substring(1, valueContent.length - 1)
+    .split(',');
 
   const bytesLengths: number[] = [];
 

--- a/src/lib/decodeData.ts
+++ b/src/lib/decodeData.ts
@@ -23,7 +23,11 @@ import { isHexStrict } from 'web3-utils';
 import { COMPACT_BYTES_ARRAY_STRING } from '../constants/constants';
 
 import { DecodeDataInput, DecodeDataOutput } from '../types/decodeData';
-import { ERC725JSONSchema } from '../types/ERC725JSONSchema';
+import {
+  ALL_VALUE_TYPES,
+  ERC725JSONSchema,
+  isValidValueType,
+} from '../types/ERC725JSONSchema';
 import { isDynamicKeyName } from './encodeKeyName';
 import { valueContentEncodingMap, decodeValueType } from './encoder';
 import { getSchemaElement } from './getSchemaElement';
@@ -66,15 +70,6 @@ export const isValidTuple = (valueType: string, valueContent: string) => {
   const valueTypeParts = extractTupleElements(valueTypeToDecode);
   const valueContentParts = extractTupleElements(valueContent);
 
-  const tuplesValidValueTypes = [
-    'bytes2',
-    'bytes4',
-    'bytes8',
-    'bytes16',
-    'bytes32',
-    'address',
-  ];
-
   if (valueTypeParts.length !== valueContentParts.length) {
     throw new Error(
       `Invalid tuple for valueType: ${valueType} / valueContent: ${valueContent}. They should have the same number of elements. Got: ${valueTypeParts.length} and ${valueContentParts.length}`,
@@ -82,9 +77,9 @@ export const isValidTuple = (valueType: string, valueContent: string) => {
   }
 
   for (let i = 0; i < valueTypeParts.length; i++) {
-    if (!tuplesValidValueTypes.includes(valueTypeParts[i])) {
+    if (!isValidValueType(valueTypeParts[i])) {
       throw new Error(
-        `Invalid tuple for valueType: ${valueType} / valueContent: ${valueContent}. Type: ${valueTypeParts[i]} is not valid. Valid types are: ${tuplesValidValueTypes}`,
+        `Invalid tuple for valueType: ${valueType} / valueContent: ${valueContent}. Type: ${valueTypeParts[i]} is not valid. Valid types are: ${ALL_VALUE_TYPES}`,
       );
     }
 

--- a/src/lib/encoder.test.ts
+++ b/src/lib/encoder.test.ts
@@ -327,8 +327,39 @@ describe('encoder', () => {
       });
     });
 
-    describe('`uint128` type', () => {
+    describe('`uintN` type', () => {
       const validTestCases = [
+        {
+          valueType: 'uint256',
+          decodedValue: 1337,
+          encodedValue:
+            '0x0000000000000000000000000000000000000000000000000000000000000539',
+        },
+        {
+          valueType: 'uint8',
+          decodedValue: 10,
+          encodedValue: '0x0a',
+        },
+        {
+          valueType: 'uint16',
+          decodedValue: 10,
+          encodedValue: '0x000a',
+        },
+        {
+          valueType: 'uint24',
+          decodedValue: 10,
+          encodedValue: '0x00000a',
+        },
+        {
+          valueType: 'uint32',
+          decodedValue: 10,
+          encodedValue: '0x0000000a',
+        },
+        {
+          valueType: 'uint64',
+          decodedValue: 25,
+          encodedValue: '0x0000000000000019',
+        },
         {
           valueType: 'uint128',
           decodedValue: 11,
@@ -350,30 +381,10 @@ describe('encoder', () => {
           );
         });
       });
-    });
 
-    describe('`uint256` type', () => {
-      const validTestCases = [
-        {
-          valueType: 'uint256',
-          decodedValue: 1337,
-          encodedValue:
-            '0x0000000000000000000000000000000000000000000000000000000000000539',
-        },
-      ];
-
-      validTestCases.forEach((testCase) => {
-        it(`encodes/decodes: ${testCase.decodedValue} as ${testCase.valueType}`, () => {
-          const encodedValue = encodeValueType(
-            testCase.valueType,
-            testCase.decodedValue,
-          );
-
-          assert.deepStrictEqual(encodedValue, testCase.encodedValue);
-          assert.deepStrictEqual(
-            decodeValueType(testCase.valueType, encodedValue),
-            testCase.decodedValue,
-          );
+      ['uint1', 'uint129', 'uint257'].forEach((invalidUintType) => {
+        it(`should error with invalid valueType for type ${invalidUintType}`, async () => {
+          assert.throws(() => encodeValueType(invalidUintType, '12345'));
         });
       });
     });

--- a/src/lib/encoder.test.ts
+++ b/src/lib/encoder.test.ts
@@ -382,10 +382,31 @@ describe('encoder', () => {
         });
       });
 
-      ['uint1', 'uint129', 'uint257'].forEach((invalidUintType) => {
-        it(`should error with invalid valueType for type ${invalidUintType}`, async () => {
-          assert.throws(() => encodeValueType(invalidUintType, '12345'));
-        });
+      it('should throw an error when trying to encode/decode with an invalid `uintN` type', async () => {
+        for (let ii = 1; ii <= 256; ii++) {
+          // only test for uintN where N is a multiple of 8
+          if (ii % 8 !== 0) {
+            assert.throws(() => encodeValueType(`uint${ii}`, 12345));
+            assert.throws(() => decodeValueType(`uint${ii}`, '0x00000001'));
+
+            // test that `uintN` are encoded / decode correct when N is not a multiple of 8
+          } else {
+            const expectedEncodedValue = `0x${'00'.repeat(ii / 8 - 1)}0a`;
+            const expectedDecodedValue = 10;
+
+            const encodedValue = encodeValueType(
+              `uint${ii}`,
+              expectedDecodedValue,
+            );
+            assert.equal(encodedValue, expectedEncodedValue);
+
+            const decodedValue = decodeValueType(
+              `uint${ii}`,
+              expectedEncodedValue,
+            );
+            assert.equal(decodedValue, expectedDecodedValue);
+          }
+        }
       });
     });
 

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -52,6 +52,7 @@ import {
   UNKNOWN_VERIFICATION_METHOD,
 } from '../constants/constants';
 import { getVerificationMethod, hashData, countNumberOfBytes } from './utils';
+import { ERC725JSONSchemaValueType } from '../types/ERC725JSONSchema';
 
 const abiCoder = AbiCoder;
 
@@ -726,13 +727,9 @@ export const valueContentEncodingMap = (valueContent: string) => {
 };
 
 export function encodeValueType(
-  type: string,
+  type: ERC725JSONSchemaValueType | string, // for tuples and CompactBytesArray,
   value: string | string[] | number | number[] | boolean | boolean[],
 ): string {
-  if (!valueTypeEncodingMap[type]) {
-    throw new Error('Could not encode valueType: "' + type + '".');
-  }
-
   if (typeof value === 'undefined' || value === null) {
     return value;
   }
@@ -740,11 +737,10 @@ export function encodeValueType(
   return valueTypeEncodingMap[type].encode(value);
 }
 
-export function decodeValueType(type: string, value: string) {
-  if (!valueTypeEncodingMap[type]) {
-    throw new Error('Could not decode valueType: "' + type + '".');
-  }
-
+export function decodeValueType(
+  type: ERC725JSONSchemaValueType | string, // for tuples and CompactBytesArray
+  value: string,
+) {
   if (value === '0x') return null;
 
   if (typeof value === 'undefined' || value === null) {

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -56,7 +56,9 @@ import { ERC725JSONSchemaValueType } from '../types/ERC725JSONSchema';
 
 const abiCoder = AbiCoder;
 
-const bytesNRegex = /Bytes(\d+)/;
+const uintNValueTypeRegex = /^uint(?:8|[1-9]\d|1[0-9]{2}|2[0-4]\d|25[0-6])$/;
+
+const BytesNValueContentRegex = /Bytes(\d+)/;
 
 const ALLOWED_BYTES_SIZES = [2, 4, 8, 16, 32, 64, 128, 256];
 
@@ -357,156 +359,209 @@ const decodeStringCompactBytesArray = (compactBytesArray: string): string[] => {
   return stringValues;
 };
 
-const valueTypeEncodingMap = {
-  bool: {
-    encode: (value: boolean) => (value ? '0x01' : '0x00'),
-    decode: (value: string) => value === '0x01',
-  },
-  boolean: {
-    encode: (value: boolean) => (value ? '0x01' : '0x00'),
-    decode: (value: string) => value === '0x01',
-  },
-  string: {
-    encode: (value: string | number) => {
-      // if we receive a number as input,
-      // convert each letter to its utf8 hex representation
-      if (typeof value === 'number') {
-        return utf8ToHex(`${value}`);
-      }
+const valueTypeEncodingMap = (
+  type: string,
+): {
+  encode: (value: any) => string;
+  decode: (value: string) => any;
+} => {
+  const uintNRegexMatch = type.match(uintNValueTypeRegex);
 
-      return utf8ToHex(value);
-    },
-    decode: (value: string) => hexToUtf8(value),
-  },
-  address: {
-    encode: (value: string) => {
-      // abi-encode pads to 32 x 00 bytes on the left, so we need to remove them
-      const abiEncodedValue = abiCoder.encodeParameter('address', value);
+  const uintLength = uintNRegexMatch
+    ? parseInt(uintNRegexMatch[0].slice(4), 10)
+    : '';
 
-      // convert to an array of individual bytes
-      const bytesArray = hexToBytes(abiEncodedValue);
+  if (type.includes('[CompactBytesArray]')) {
+    const compactBytesArrayMap = {
+      'bytes[CompactBytesArray]': {
+        encode: (value: string[]) => encodeCompactBytesArray(value),
+        decode: (value: string) => decodeCompactBytesArray(value),
+      },
+      'string[CompactBytesArray]': {
+        encode: (value: string[]) => encodeStringCompactBytesArray(value),
+        decode: (value: string) => decodeStringCompactBytesArray(value),
+      },
+      ...returnTypesOfBytesNCompactBytesArray(),
+      ...returnTypesOfUintNCompactBytesArray(),
+    };
 
-      // just keep the last 20 bytes, starting at index 12
-      return bytesToHex(bytesArray.slice(12));
-    },
-    decode: (value: string) => toChecksumAddress(value),
-  },
-  // NOTE: We could add conditional handling of numeric values here...
-  uint128: {
-    encode: (value: string | number) => {
-      const abiEncodedValue = abiCoder.encodeParameter('uint128', value);
-      const bytesArray = hexToBytes(abiEncodedValue);
-      return bytesToHex(bytesArray.slice(16));
-    },
-    decode: (value: string) => {
-      if (!isHex(value)) {
-        throw new Error(`Can't convert ${value} to uint128, value is not hex.`);
-      }
+    return compactBytesArrayMap[type];
+  }
 
-      if (value.length > 34) {
-        throw new Error(
-          `Can't convert hex value ${value} to uint128. Too many bytes. ${
-            (value.length - 2) / 2
-          } > 16`,
-        );
-      }
+  switch (type) {
+    case 'bool':
+    case 'boolean':
+      return {
+        encode: (value: boolean) => (value ? '0x01' : '0x00'),
+        decode: (value: string) => value === '0x01',
+      };
+    case 'string':
+      return {
+        encode: (value: string | number) => {
+          // if we receive a number as input, convert each letter to its utf8 hex representation
+          if (typeof value === 'number') {
+            return utf8ToHex(`${value}`);
+          }
 
-      return toBN(value).toNumber();
-    },
-  },
-  uint256: {
-    encode: (value: string | number) => {
-      return abiCoder.encodeParameter('uint256', value);
-    },
-    decode: (value: string) => {
-      if (!isHex(value)) {
-        throw new Error(`Can't convert ${value} to uint256, value is not hex.`);
-      }
+          return utf8ToHex(value);
+        },
+        decode: (value: string) => hexToUtf8(value),
+      };
+    case 'address':
+      return {
+        encode: (value: string) => {
+          // abi-encode pads to 32 x 00 bytes on the left, so we need to remove them
+          const abiEncodedValue = abiCoder.encodeParameter('address', value);
 
-      const numberOfBytes = countNumberOfBytes(value);
+          // convert to an array of individual bytes
+          const bytesArray = hexToBytes(abiEncodedValue);
 
-      if (numberOfBytes > 32) {
-        throw new Error(
-          `Can't convert hex value ${value} to uint256. Too many bytes. ${numberOfBytes} is above the maximal number of bytes 32.`,
-        );
-      }
+          // just keep the last 20 bytes, starting at index 12
+          return bytesToHex(bytesArray.slice(12));
+        },
+        decode: (value: string) => toChecksumAddress(value),
+      };
+    // NOTE: We could add conditional handling of numeric values here...
+    case `uint${uintLength}`:
+      return {
+        encode: (value: string | number) => {
+          const abiEncodedValue = abiCoder.encodeParameter(type, value);
 
-      return toBN(value).toNumber();
-    },
-  },
-  bytes32: {
-    encode: (value: string | number) => encodeToBytesN('bytes32', value),
-    decode: (value: string) => abiCoder.decodeParameter('bytes32', value),
-  },
-  bytes4: {
-    encode: (value: string | number) => encodeToBytesN('bytes4', value),
-    decode: (value: string) => {
-      // we need to abi-encode the value again to ensure that:
-      //  - that data to decode does not go over 4 bytes.
-      //  - if the data is less than 4 bytes, that it gets padded to 4 bytes long.
-      const reEncodedData = abiCoder.encodeParameter('bytes4', value);
-      return abiCoder.decodeParameter('bytes4', reEncodedData);
-    },
-  },
-  bytes: {
-    encode: (value: string) => toHex(value),
-    decode: (value: string) => value,
-  },
-  'bool[]': {
-    encode: (value: boolean) => abiCoder.encodeParameter('bool[]', value),
-    decode: (value: string) => abiCoder.decodeParameter('bool[]', value),
-  },
-  'boolean[]': {
-    encode: (value: boolean) => abiCoder.encodeParameter('bool[]', value),
-    decode: (value: string) => abiCoder.decodeParameter('bool[]', value),
-  },
-  'string[]': {
-    encode: (value: string[]) => abiCoder.encodeParameter('string[]', value),
-    decode: (value: string) => abiCoder.decodeParameter('string[]', value),
-  },
-  'address[]': {
-    encode: (value: string[]) => abiCoder.encodeParameter('address[]', value),
-    decode: (value: string) => abiCoder.decodeParameter('address[]', value),
-  },
-  'uint256[]': {
-    encode: (value: Array<number | string>) =>
-      abiCoder.encodeParameter('uint256[]', value),
-    decode: (value: string) => {
-      // we want to return an array of numbers as [1, 2, 3], not an array of strings as [ '1', '2', '3']
-      return abiCoder
-        .decodeParameter('uint256[]', value)
-        .map((numberAsString) => parseInt(numberAsString, 10));
-    },
-  },
-  'bytes32[]': {
-    encode: (value: string[]) => abiCoder.encodeParameter('bytes32[]', value),
-    decode: (value: string) => abiCoder.decodeParameter('bytes32[]', value),
-  },
-  'bytes4[]': {
-    encode: (value: string[]) => abiCoder.encodeParameter('bytes4[]', value),
-    decode: (value: string) => abiCoder.decodeParameter('bytes4[]', value),
-  },
-  'bytes[]': {
-    encode: (value: string[]) => abiCoder.encodeParameter('bytes[]', value),
-    decode: (value: string) => abiCoder.decodeParameter('bytes[]', value),
-  },
-  'bytes[CompactBytesArray]': {
-    encode: (value: string[]) => encodeCompactBytesArray(value),
-    decode: (value: string) => decodeCompactBytesArray(value),
-  },
-  'string[CompactBytesArray]': {
-    encode: (value: string[]) => encodeStringCompactBytesArray(value),
-    decode: (value: string) => decodeStringCompactBytesArray(value),
-  },
-  ...returnTypesOfBytesNCompactBytesArray(),
-  ...returnTypesOfUintNCompactBytesArray(),
+          const bytesArray = hexToBytes(abiEncodedValue);
+          const numberOfBytes = (uintLength as number) / 8;
+
+          // abi-encoding always pad to 32 bytes. We need to keep the `n` rightmost bytes.
+          // where `n` = `numberOfBytes`
+          const startIndex = 32 - numberOfBytes;
+
+          return bytesToHex(bytesArray.slice(startIndex));
+        },
+        decode: (value: string) => {
+          if (!isHex(value)) {
+            throw new Error(
+              `Can't convert ${value} to ${type}, value is not hex.`,
+            );
+          }
+
+          const numberOfBytes = countNumberOfBytes(value);
+
+          if (numberOfBytes > (uintLength as number) / 8) {
+            throw new Error(
+              `Can't convert hex value ${value} to ${type}. Too many bytes. ${numberOfBytes} > 16`,
+            );
+          }
+
+          return toBN(value).toNumber();
+        },
+      };
+    case 'bytes32':
+      return {
+        encode: (value: string | number) => encodeToBytesN('bytes32', value),
+        decode: (value: string) => abiCoder.decodeParameter('bytes32', value),
+      };
+    case 'bytes4':
+      return {
+        encode: (value: string | number) => encodeToBytesN('bytes4', value),
+        decode: (value: string) => {
+          // we need to abi-encode the value again to ensure that:
+          //  - that data to decode does not go over 4 bytes.
+          //  - if the data is less than 4 bytes, that it gets padded to 4 bytes long.
+          const reEncodedData = abiCoder.encodeParameter('bytes4', value);
+          return abiCoder.decodeParameter('bytes4', reEncodedData);
+        },
+      };
+    case 'bytes':
+      return {
+        encode: (value: string) => toHex(value),
+        decode: (value: string) => value,
+      };
+    case 'bool[]':
+      return {
+        encode: (value: boolean) => abiCoder.encodeParameter('bool[]', value),
+        decode: (value: string) => abiCoder.decodeParameter('bool[]', value),
+      };
+    case 'boolean[]':
+      return {
+        encode: (value: boolean) => abiCoder.encodeParameter('bool[]', value),
+        decode: (value: string) => abiCoder.decodeParameter('bool[]', value),
+      };
+    case 'string[]':
+      return {
+        encode: (value: string[]) =>
+          abiCoder.encodeParameter('string[]', value),
+        decode: (value: string) => abiCoder.decodeParameter('string[]', value),
+      };
+    case 'address[]':
+      return {
+        encode: (value: string[]) =>
+          abiCoder.encodeParameter('address[]', value),
+        decode: (value: string) => abiCoder.decodeParameter('address[]', value),
+      };
+    case 'uint256[]':
+      return {
+        encode: (value: Array<number | string>) =>
+          abiCoder.encodeParameter('uint256[]', value),
+        decode: (value: string) => {
+          // we want to return an array of numbers as [1, 2, 3], not an array of strings as [ '1', '2', '3']
+          return abiCoder
+            .decodeParameter('uint256[]', value)
+            .map((numberAsString) => parseInt(numberAsString, 10));
+        },
+      };
+    case 'bytes32[]':
+      return {
+        encode: (value: string[]) =>
+          abiCoder.encodeParameter('bytes32[]', value),
+        decode: (value: string) => abiCoder.decodeParameter('bytes32[]', value),
+      };
+    case 'bytes4[]':
+      return {
+        encode: (value: string[]) =>
+          abiCoder.encodeParameter('bytes4[]', value),
+        decode: (value: string) => abiCoder.decodeParameter('bytes4[]', value),
+      };
+    case 'bytes[]':
+      return {
+        encode: (value: string[]) => abiCoder.encodeParameter('bytes[]', value),
+        decode: (value: string) => abiCoder.decodeParameter('bytes[]', value),
+      };
+    case 'bytes[CompactBytesArray]':
+      return {
+        encode: (value: string[]) => encodeCompactBytesArray(value),
+        decode: (value: string) => decodeCompactBytesArray(value),
+      };
+    case 'string[CompactBytesArray]':
+      return {
+        encode: (value: string[]) => encodeStringCompactBytesArray(value),
+        decode: (value: string) => decodeStringCompactBytesArray(value),
+      };
+    default:
+      return {
+        encode: (value: any) => {
+          throw new Error(
+            `Could not encode ${value}. Value type ${type} is unknown`,
+          );
+        },
+        decode: (value: any) => {
+          throw new Error(
+            `Could not decode ${value}. Value type ${type} is unknown`,
+          );
+        },
+      };
+  }
 };
 
 // Use enum for type below
 // Is it this enum ERC725JSONSchemaValueType? (If so, custom is missing from enum)
 
-export const valueContentEncodingMap = (valueContent: string) => {
-  const bytesNRegexMatch = valueContent.match(bytesNRegex);
+export const valueContentEncodingMap = (
+  valueContent: string,
+): {
+  type: string;
+  encode: (value: any) => string;
+  decode: (value: string) => any;
+} => {
+  const bytesNRegexMatch = valueContent.match(BytesNValueContentRegex);
   const bytesLength = bytesNRegexMatch ? parseInt(bytesNRegexMatch[1], 10) : '';
 
   switch (valueContent) {
@@ -694,12 +749,12 @@ export const valueContentEncodingMap = (valueContent: string) => {
     case 'Boolean': {
       return {
         type: 'bool',
-        encode: (value): string => {
-          return valueTypeEncodingMap.bool.encode(value);
+        encode: (value: boolean): string => {
+          return valueTypeEncodingMap('bool').encode(value);
         },
         decode: (value: string): boolean => {
           try {
-            return valueTypeEncodingMap.bool.decode(value) as any as boolean;
+            return valueTypeEncodingMap('bool').decode(value) as any as boolean;
           } catch (error) {
             throw new Error(`Value ${value} is not a boolean`);
           }
@@ -734,7 +789,7 @@ export function encodeValueType(
     return value;
   }
 
-  return valueTypeEncodingMap[type].encode(value);
+  return valueTypeEncodingMap(type).encode(value);
 }
 
 export function decodeValueType(
@@ -747,7 +802,7 @@ export function decodeValueType(
     return value;
   }
 
-  return valueTypeEncodingMap[type].decode(value);
+  return valueTypeEncodingMap(type).decode(value);
 }
 
 export function encodeValueContent(

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -581,3 +581,13 @@ export function patchIPFSUrlsIfApplicable(
 export function countNumberOfBytes(data: string) {
   return stripHexPrefix(data).length / 2;
 }
+
+/**
+ * `uintN` must be a valid number of bits between 8 and 256, in multiple of 8
+ * e.g: uint8, uint16, uint24, uint32, ..., uint256
+ *
+ * @param bitSize the size of the uint in bits
+ */
+export function isValidUintSize(bitSize: number) {
+  return bitSize >= 8 && bitSize <= 256 && bitSize % 8 === 0;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -71,7 +71,7 @@ import { isValidTuple } from './decodeData';
  */
 export function encodeKeyValue(
   valueContent: string,
-  valueType: ERC725JSONSchemaValueType,
+  valueType: ERC725JSONSchemaValueType | string,
   decodedValue:
     | string
     | string[]
@@ -360,7 +360,7 @@ export function encodeKey(
  */
 export function decodeKeyValue(
   valueContent: string,
-  valueType: ERC725JSONSchemaValueType,
+  valueType: ERC725JSONSchemaValueType | string, // string for tuples and CompactBytesArray
   value,
   name?: string,
 ) {

--- a/src/types/ERC725JSONSchema.ts
+++ b/src/types/ERC725JSONSchema.ts
@@ -18,24 +18,131 @@ export type ERC725JSONSchemaValueContent =
   | 'Boolean'
   | string; // for tuples
 
-export type ERC725JSONSchemaValueType =
-  | 'bool'
-  | 'boolean'
-  | 'string'
-  | 'address'
-  | 'uint256'
-  | 'bytes32'
-  | 'bytes'
-  | 'bytes4'
-  | 'string[]'
-  | 'address[]'
-  | 'uint256[]'
-  | 'bytes32[]'
-  | 'bytes4[]'
-  | 'bytes[]'
-  | 'bool[]'
-  | 'boolean[]'
-  | string; // for tuples;
+export const ALL_VALUE_TYPES = [
+  // unsigned integers
+  'uint8',
+  'uint16',
+  'uint24',
+  'uint32',
+  'uint40',
+  'uint48',
+  'uint56',
+  'uint64',
+  'uint72',
+  'uint80',
+  'uint88',
+  'uint96',
+  'uint104',
+  'uint112',
+  'uint120',
+  'uint128',
+  'uint136',
+  'uint144',
+  'uint152',
+  'uint160',
+  'uint168',
+  'uint176',
+  'uint184',
+  'uint192',
+  'uint200',
+  'uint208',
+  'uint216',
+  'uint224',
+  'uint232',
+  'uint240',
+  'uint248',
+  'uint256',
+  // signed integers
+  'int8',
+  'int16',
+  'int24',
+  'int32',
+  'int40',
+  'int48',
+  'int56',
+  'int64',
+  'int72',
+  'int80',
+  'int88',
+  'int96',
+  'int104',
+  'int112',
+  'int120',
+  'int128',
+  'int136',
+  'int144',
+  'int152',
+  'int160',
+  'int168',
+  'int176',
+  'int184',
+  'int192',
+  'int200',
+  'int208',
+  'int216',
+  'int224',
+  'int232',
+  'int240',
+  'int248',
+  'int256',
+  // bytesN
+  'bytes1',
+  'bytes2',
+  'bytes3',
+  'bytes4',
+  'bytes5',
+  'bytes6',
+  'bytes7',
+  'bytes8',
+  'bytes9',
+  'bytes10',
+  'bytes11',
+  'bytes12',
+  'bytes13',
+  'bytes14',
+  'bytes15',
+  'bytes16',
+  'bytes17',
+  'bytes18',
+  'bytes19',
+  'bytes20',
+  'bytes21',
+  'bytes22',
+  'bytes23',
+  'bytes24',
+  'bytes25',
+  'bytes26',
+  'bytes27',
+  'bytes28',
+  'bytes29',
+  'bytes30',
+  'bytes31',
+  'bytes32',
+  // others static types
+  'bool',
+  'boolean',
+  'address',
+  // array and dynamic types
+  'string',
+  'bytes',
+  // arrays
+  'string[]',
+  'address[]',
+  'uint256[]',
+  'bytes32[]',
+  'bytes4[]',
+  'bytes[]',
+  'bool[]',
+  'boolean[]',
+] as const;
+
+export type ERC725JSONSchemaValueType = (typeof ALL_VALUE_TYPES)[number];
+
+export function isValidValueType(
+  value: string,
+): value is ERC725JSONSchemaValueType {
+  return ALL_VALUE_TYPES.includes(value as ERC725JSONSchemaValueType);
+}
 
 /**
  * ```javascript title=Example
@@ -54,5 +161,5 @@ export interface ERC725JSONSchema {
   key: string; // The keccak256 hash of the name. This is the actual key that MUST be retrievable via ERC725Y.getData(bytes32 key)
   keyType: ERC725JSONSchemaKeyType; // Types that determine how the values should be interpreted.
   valueContent: ERC725JSONSchemaValueContent | string; // string holds '0x1345ABCD...' If the value content are specific bytes, than the returned value is expected to equal those bytes.
-  valueType: ERC725JSONSchemaValueType;
+  valueType: ERC725JSONSchemaValueType | string; // The type of the value. This is used to determine how the value should be encoded / decode (`string` for tuples and CompactBytesArray).
 }


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

**New feature**

### What is the current behaviour (you can also link to an open issue here)?

Currently, erc725.js allows to encode only numbers `valueType` of `uint128` or `uint256`.
Any other type available in the 8 bit range from Solidity are not available.

### What is the new behaviour (if this is a feature change)?

Refactor the value type map to filter by regex and allow to encode number from `uint8` to `uint256`.

### Other information:
