### PR TITLE
fix: Add workaround to read (bytes4,URI), repair unknown signature to pass.

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -92,7 +92,7 @@ export const METHODS: Record<Method, MethodData> = {
   },
 };
 
-export const UNKNOWN_VERIFICATION_METHOD = 'unknown';
+export const NONE_VERIFICATION_METHOD = '0x00000000';
 
 export enum SUPPORTED_VERIFICATION_METHOD_STRINGS {
   KECCAK256_UTF8 = 'keccak256(utf8)',

--- a/src/lib/encoder.test.ts
+++ b/src/lib/encoder.test.ts
@@ -32,6 +32,7 @@ import {
   decodeValueContent,
 } from './encoder';
 import {
+  NONE_VERIFICATION_METHOD,
   SUPPORTED_VERIFICATION_METHOD_HASHES,
   SUPPORTED_VERIFICATION_METHOD_STRINGS,
 } from '../constants/constants';
@@ -925,6 +926,20 @@ describe('encoder', () => {
           '0x00006f357c6a0020027547537d35728a741470df1ccf65de10b454ca0def7c5c20b257b7b8d16168687474703a2f2f746573742e636f6d2f61737365742e676c62',
       },
       {
+        valueContent: 'VerifiableURI', // Actual content is (bytes4,URI)
+        decodedValue: {
+          verification: {
+            method: NONE_VERIFICATION_METHOD,
+            data: '0x',
+          },
+          url: 'https://name.universal.page/',
+        },
+        encodedValue:
+          '0x6f357c6a68747470733a2f2f6e616d652e756e6976657273616c2e706167652f',
+        reencodedValue:
+          '0x000000000000000068747470733a2f2f6e616d652e756e6976657273616c2e706167652f',
+      },
+      {
         valueContent: 'BitArray',
         encodedValue:
           '0x0000000000000000000000000000000000000000000000000000000000000008', // ... 0000 0000 1000
@@ -952,7 +967,10 @@ describe('encoder', () => {
 
         encodeValueContent(testCase.valueContent, testCase.decodedValue);
 
-        assert.deepStrictEqual(encodedValue, testCase.encodedValue);
+        assert.deepStrictEqual(
+          encodedValue,
+          testCase.reencodedValue || testCase.encodedValue,
+        );
         assert.deepStrictEqual(
           encodedValue !== false
             ? decodeValueContent(testCase.valueContent, encodedValue)

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -136,7 +136,7 @@ const decodeDataSourceWithHash = (value: string): URLDataWithHash => {
 
   try {
     const dataSource = hexToUtf8('0x' + encodedData); // Get as URI
-    if (encodedData.length < 64 || /^[a-z]{2,}:/.test(dataSource)) {
+    if (encodedData.length < 64 || /^[a-z]{2,}:[/\S]/.test(dataSource)) {
       return {
         verification: {
           method: NONE_VERIFICATION_METHOD,

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -136,8 +136,7 @@ const decodeDataSourceWithHash = (value: string): URLDataWithHash => {
 
   try {
     const dataSource = hexToUtf8('0x' + encodedData); // Get as URI
-    if (encodedData.length < 64 || /^(https?|ipfs):\/\//.test(dataSource)) {
-      console.log(dataSource);
+    if (encodedData.length < 64 || /^[a-z]{2,}:/.test(dataSource)) {
       return {
         verification: {
           method: NONE_VERIFICATION_METHOD,

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -119,11 +119,7 @@ const decodeDataSourceWithHash = (value: string): URLDataWithHash => {
 
     return {
       verification: {
-        method:
-          verificationMethod?.name ||
-          (verificationMethodSignature === '0x00000000'
-            ? NONE_VERIFICATION_METHOD
-            : verificationMethodSignature),
+        method: verificationMethod?.name || verificationMethodSignature,
         data: dataHash,
       },
       url: dataSource,
@@ -154,11 +150,7 @@ const decodeDataSourceWithHash = (value: string): URLDataWithHash => {
 
   return {
     verification: {
-      method:
-        verificationMethod?.name ||
-        (verificationMethodSignature === '0x00000000'
-          ? NONE_VERIFICATION_METHOD
-          : verificationMethodSignature),
+      method: verificationMethod?.name || verificationMethodSignature,
       data: dataHash,
     },
     url: dataSource,


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

Add workaround to read old (bytes4,URI) as a VerifiableURI without verification.
Allow 0x00000000 verification everywhere and don't convert it to unknown
Pass unknown verification signatures back.

### What is the current behaviour (you can also link to an open issue here)?

Both 0x00000000 and unknown turn into "unknown" making it impossible to create third party verification methods while using erc725.js
We were unable to read the old (bytes4,URI) for LSP8TokenMetadataBaseURI

### What is the new behaviour (if this is a feature change)?

LSP8TokenMetadataBaseURI is converted and returns as VerifiableURI information.
Saving and retrieving an unknown verification methods is now possible with getData
The 0x00000000 method is now defined as a constant as well.

### Other information:
