### PR TITLE
fix: Make data retrieval more resilient. Do not throw on ipfs data problems.

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -569,7 +569,6 @@ describe('Running @erc725/erc725.js tests...', () => {
           ),
         );
         const result = await erc725.fetchData('TestJSONURL');
-        console.log(fetchStub.getCalls(), result);
         fetchStub.restore();
 
         assert.deepStrictEqual(result, {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -561,8 +561,15 @@ describe('Running @erc725/erc725.js tests...', () => {
         const jsonString = `{"LSP3Profile":{"profileImage":"ipfs://QmYo8yg4zzmdu26NSvtsoKeU5oVR6h2ohmoa2Cx5i91mPf","backgroundImage":"ipfs://QmZF5pxDJcB8eVvCd74rsXBFXhWL3S1XR5tty2cy1a58Ew","description":"Beautiful clothing that doesn't cost the Earth. A sustainable designer based in London Patrick works with brand partners to refocus on systemic change centred around creative education. "}}`;
 
         const fetchStub = sinon.stub(global, 'fetch');
-        fetchStub.onCall(0).returns(Promise.resolve(new Response(jsonString)));
+        fetchStub.onCall(0).returns(
+          Promise.resolve(
+            new Response(jsonString, {
+              headers: { 'content-type': 'application/json' },
+            }),
+          ),
+        );
         const result = await erc725.fetchData('TestJSONURL');
+        console.log(fetchStub.getCalls(), result);
         fetchStub.restore();
 
         assert.deepStrictEqual(result, {
@@ -584,7 +591,7 @@ describe('Running @erc725/erc725.js tests...', () => {
           [contractVersion.interface],
         );
 
-        const ipfsGateway = 'https://2eff.lukso.dev';
+        const ipfsGateway = 'https://api.universalprofile.cloud';
 
         const erc725 = new ERC725([testJSONURLSchema], address, provider, {
           ipfsGateway,
@@ -593,7 +600,13 @@ describe('Running @erc725/erc725.js tests...', () => {
         const jsonString = `{"LSP3Profile":{"profileImage":"ipfs://QmYo8yg4zzmdu26NSvtsoKeU5oVR6h2ohmoa2Cx5i91mPf","backgroundImage":"ipfs://QmZF5pxDJcB8eVvCd74rsXBFXhWL3S1XR5tty2cy1a58Ew","description":"Beautiful clothing that doesn't cost the Earth. A sustainable designer based in London Patrick works with brand partners to refocus on systemic change centred around creative education. "}}`;
 
         const fetchStub = sinon.stub(global, 'fetch');
-        fetchStub.onCall(0).returns(Promise.resolve(new Response(jsonString)));
+        fetchStub.onCall(0).returns(
+          Promise.resolve(
+            new Response(jsonString, {
+              headers: { 'content-type': 'application/json' },
+            }),
+          ),
+        );
         const result = await erc725.fetchData('TestJSONURL');
         assert.deepStrictEqual(result, {
           key: testJSONURLSchema.key,

--- a/src/lib/decodeData.test.ts
+++ b/src/lib/decodeData.test.ts
@@ -92,6 +92,11 @@ describe('decodeData', () => {
             '0x6f357c6a820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361696670733a2f2f516d597231564a4c776572673670456f73636468564775676f3339706136727963455a4c6a7452504466573834554178',
         },
         {
+          keyName: 'JSONURLCase',
+          value:
+            '0x8019f9b1820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361696670733a2f2f516d597231564a4c776572673670456f73636468564775676f3339706136727963455a4c6a7452504466573834554178',
+        },
+        {
           keyName: 'AssetURLCase',
           value:
             '0x8019f9b1d47cf10786205bb08ce508e91c424d413d0f6c48e24dbfde2920d16a9561a723697066733a2f2f516d57346e554e7933767476723344785a48754c66534c6e687a4b4d6532576d67735573454750504668385a7470',
@@ -100,6 +105,13 @@ describe('decodeData', () => {
       [
         {
           name: 'JSONURLCase',
+          key: '0x9136feeb09af67b63993b586ce46a43bd3456990d3fdb39d07beab9dee8d5910',
+          keyType: 'Singleton',
+          valueType: 'bytes',
+          valueContent: 'JSONURL', // Deprecated - We keep it for backward compatibility between v0.21.3 and v0.22.0
+        },
+        {
+          name: 'JSONURLCase2',
           key: '0x9136feeb09af67b63993b586ce46a43bd3456990d3fdb39d07beab9dee8d5910',
           keyType: 'Singleton',
           valueType: 'bytes',
@@ -119,6 +131,13 @@ describe('decodeData', () => {
       {
         verification: {
           method: 'keccak256(utf8)', // 0x6f357c6a
+          data: '0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361',
+        },
+        url: 'ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx',
+      },
+      {
+        verification: {
+          method: 'keccak256(bytes)', // 0x8019f9b1
           data: '0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361',
         },
         url: 'ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx',
@@ -177,6 +196,44 @@ describe('decodeData', () => {
           {
             key: '0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd',
             value: '0x00000000000000000000000000000002',
+          },
+          {
+            key: '0x7c8c3416d6cda87cd42c71ea1843df2800000000000000000000000000000000',
+            value: '0xd94353d9b005b3c0a9da169b768a31c57844e490',
+          },
+          {
+            key: '0x7c8c3416d6cda87cd42c71ea1843df2800000000000000000000000000000001',
+            value: '0xdaea594e385fc724449e3118b2db7e86dfba1826',
+          },
+        ],
+      },
+      [
+        {
+          name: 'LSP12IssuedAssets[]',
+          key: '0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd',
+          keyType: 'Array',
+          valueContent: 'Address',
+          valueType: 'address',
+        },
+      ],
+    );
+
+    expect(decodedData.name).to.eql('LSP12IssuedAssets[]');
+    expect(decodedData.value).to.eql([
+      '0xD94353D9B005B3c0A9Da169b768a31C57844e490',
+      '0xDaea594E385Fc724449E3118B2Db7E86dFBa1826',
+    ]);
+  });
+
+  it('parses type Array correctly (even with uint256)', () => {
+    const decodedData = decodeData(
+      {
+        keyName: 'LSP12IssuedAssets[]',
+        value: [
+          {
+            key: '0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd',
+            value:
+              '0x0000000000000000000000000000000000000000000000000000000000000002',
           },
           {
             key: '0x7c8c3416d6cda87cd42c71ea1843df2800000000000000000000000000000000',

--- a/src/lib/encoder.test.ts
+++ b/src/lib/encoder.test.ts
@@ -38,7 +38,7 @@ import {
 } from '../constants/constants';
 import { URLDataToEncode, URLDataWithHash } from '../types';
 
-describe('encoder', () => {
+describe.only('encoder', () => {
   describe('valueType', () => {
     describe('`bool`/`boolean` type', () => {
       const validTestCases = [
@@ -667,13 +667,15 @@ describe('encoder', () => {
         );
       });
 
-      it('throws when trying to decode a bytes17 as `uint128`', () => {
-        expect(() =>
-          decodeValueType('uint128', '0x000000000000000000000000000000ffff'),
-        ).to.throw(
-          "Can't convert hex value 0x000000000000000000000000000000ffff to uint128. Too many bytes. 17 > 16",
-        );
-      });
+      // We do not want this during decode. During encode we enforce the correct sizes.
+      //
+      // it('throws when trying to decode a bytes17 as `uint128`', () => {
+      //   expect(() =>
+      //     decodeValueType('uint128', '0x000000000000000000000000000000ffff'),
+      //   ).to.throw(
+      //     "Can't convert hex value 0x000000000000000000000000000000ffff to uint128. Too many bytes. 17 > 16",
+      //   );
+      // });
     });
 
     describe('`type[CompactBytesArray]` (of static types)', () => {

--- a/src/lib/encoder.test.ts
+++ b/src/lib/encoder.test.ts
@@ -38,7 +38,7 @@ import {
 } from '../constants/constants';
 import { URLDataToEncode, URLDataWithHash } from '../types';
 
-describe.only('encoder', () => {
+describe('encoder', () => {
   describe('valueType', () => {
     describe('`bool`/`boolean` type', () => {
       const validTestCases = [

--- a/src/lib/encoder.test.ts
+++ b/src/lib/encoder.test.ts
@@ -667,15 +667,18 @@ describe('encoder', () => {
         );
       });
 
-      // We do not want this during decode. During encode we enforce the correct sizes.
-      //
-      // it('throws when trying to decode a bytes17 as `uint128`', () => {
-      //   expect(() =>
-      //     decodeValueType('uint128', '0x000000000000000000000000000000ffff'),
-      //   ).to.throw(
-      //     "Can't convert hex value 0x000000000000000000000000000000ffff to uint128. Too many bytes. 17 > 16",
-      //   );
-      // });
+      // We do not want to throw an Exception during decode. During encode we enforce the correct sizes.
+      // If there is a value size exception then we should throw.
+
+      it('throws when trying to decode a bytes17 as `uint128`', () => {
+        assert.equal(
+          decodeValueType('uint128', '0x000000000000000000000000000000ffff'),
+          '0xffff',
+        );
+        assert.throws(() =>
+          decodeValueType('uint128', '0x0100000000000000000000000000000000'),
+        );
+      });
     });
 
     describe('`type[CompactBytesArray]` (of static types)', () => {

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -506,13 +506,24 @@ const valueTypeEncodingMap = (
             );
           }
           const abiEncodedValue = abiCoder.encodeParameter(type, value);
-
+          console.log(value, abiEncodedValue);
           const bytesArray = hexToBytes(abiEncodedValue);
           const numberOfBytes = (uintLength as number) / 8;
-
           // abi-encoding always pad to 32 bytes. We need to keep the `n` rightmost bytes.
           // where `n` = `numberOfBytes`
           const startIndex = 32 - numberOfBytes;
+
+          console.log(
+            bytesArray,
+            startIndex,
+            bytesArray.slice(0, startIndex),
+            bytesArray.slice(startIndex),
+          );
+          if (bytesArray.slice(0, startIndex).some((byte) => byte !== 0)) {
+            throw Error(
+              `Number ${value} is too large to be represented as ${type}`,
+            );
+          }
 
           return bytesToHex(bytesArray.slice(startIndex));
         },

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -72,7 +72,7 @@ const encodeDataSourceWithHash = (
   dataSource: string,
 ): string => {
   const verificationMethod = getVerificationMethod(
-    verification?.method || '0x00000000',
+    verification?.method || NONE_VERIFICATION_METHOD,
   );
   return [
     '0x0000',

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -529,11 +529,12 @@ const valueTypeEncodingMap = (
             );
           }
 
+          // Although this is "wrong" making this a real Exception prevents people from using the library
+          // rather than encouraging them to fix the problem. Making this a console error.
           const numberOfBytes = countNumberOfBytes(value);
-
           if (numberOfBytes > (uintLength as number) / 8) {
-            throw new Error(
-              `Can't convert hex value ${value} to ${type}. Too many bytes. ${numberOfBytes} > 16`,
+            console.error(
+              `Invalid length hex value ${value} to ${type}. Too many bytes. ${numberOfBytes} > 16`,
             );
           }
 

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -506,19 +506,11 @@ const valueTypeEncodingMap = (
             );
           }
           const abiEncodedValue = abiCoder.encodeParameter(type, value);
-          console.log(value, abiEncodedValue);
           const bytesArray = hexToBytes(abiEncodedValue);
           const numberOfBytes = (uintLength as number) / 8;
           // abi-encoding always pad to 32 bytes. We need to keep the `n` rightmost bytes.
           // where `n` = `numberOfBytes`
           const startIndex = 32 - numberOfBytes;
-
-          console.log(
-            bytesArray,
-            startIndex,
-            bytesArray.slice(0, startIndex),
-            bytesArray.slice(startIndex),
-          );
           if (bytesArray.slice(0, startIndex).some((byte) => byte !== 0)) {
             throw Error(
               `Number ${value} is too large to be represented as ${type}`,
@@ -794,7 +786,7 @@ export const valueContentEncodingMap = (
         },
         decode: (value: string) => {
           if (typeof value !== 'string' || !isHex(value)) {
-            console.log(`Value: ${value} is not hex.`);
+            console.error(`Value: ${value} is not hex.`);
             return null;
           }
 

--- a/src/lib/getDataFromExternalSources.ts
+++ b/src/lib/getDataFromExternalSources.ts
@@ -77,6 +77,9 @@ export const getDataFromExternalSources = (
       const { url } = patchIPFSUrlsIfApplicable(urlDataWithHash, ipfsGateway);
 
       receivedData = await fetch(url).then(async (response) => {
+        if (!response.ok) {
+          return undefined;
+        }
         if (
           urlDataWithHash.verification?.method ===
           SUPPORTED_VERIFICATION_METHOD_STRINGS.KECCAK256_BYTES
@@ -85,7 +88,6 @@ export const getDataFromExternalSources = (
             .arrayBuffer()
             .then((buffer) => new Uint8Array(buffer));
         }
-
         return response.json();
       });
     } catch (error) {

--- a/src/lib/getDataFromExternalSources.ts
+++ b/src/lib/getDataFromExternalSources.ts
@@ -77,6 +77,7 @@ export const getDataFromExternalSources = (
       const { url } = patchIPFSUrlsIfApplicable(urlDataWithHash, ipfsGateway);
 
       receivedData = await fetch(url).then(async (response) => {
+        console.log(receivedData, urlDataWithHash, response);
         if (!response.ok) {
           return undefined;
         }
@@ -90,8 +91,14 @@ export const getDataFromExternalSources = (
         }
         return response.json();
       });
+      console.log(
+        receivedData,
+        urlDataWithHash,
+        receivedData,
+        urlDataWithHash.verification,
+      );
       if (isDataAuthentic(receivedData, urlDataWithHash.verification)) {
-        return dataEntry;
+        return { ...dataEntry, value: receivedData };
       }
       console.error(
         `GET request to ${urlDataWithHash.url} did not correctly validate`,

--- a/src/lib/getDataFromExternalSources.ts
+++ b/src/lib/getDataFromExternalSources.ts
@@ -77,7 +77,6 @@ export const getDataFromExternalSources = (
       const { url } = patchIPFSUrlsIfApplicable(urlDataWithHash, ipfsGateway);
 
       receivedData = await fetch(url).then(async (response) => {
-        console.log(receivedData, urlDataWithHash, response);
         if (!response.ok) {
           return undefined;
         }
@@ -91,12 +90,6 @@ export const getDataFromExternalSources = (
         }
         return response.json();
       });
-      console.log(
-        receivedData,
-        urlDataWithHash,
-        receivedData,
-        urlDataWithHash.verification,
-      );
       if (isDataAuthentic(receivedData, urlDataWithHash.verification)) {
         return { ...dataEntry, value: receivedData };
       }

--- a/src/lib/getDataFromExternalSources.ts
+++ b/src/lib/getDataFromExternalSources.ts
@@ -90,14 +90,17 @@ export const getDataFromExternalSources = (
         }
         return response.json();
       });
+      if (isDataAuthentic(receivedData, urlDataWithHash.verification)) {
+        return dataEntry;
+      }
+      console.error(
+        `GET request to ${urlDataWithHash.url} did not correctly validate`,
+      );
     } catch (error) {
       console.error(error, `GET request to ${urlDataWithHash.url} failed`);
-      throw error;
     }
-
-    return isDataAuthentic(receivedData, urlDataWithHash.verification)
-      ? { ...dataEntry, value: receivedData }
-      : { ...dataEntry, value: null };
+    // Invalid data
+    return { ...dataEntry, value: null };
   });
 
   return Promise.all(promises);

--- a/src/lib/provider-wrapper-utils.ts
+++ b/src/lib/provider-wrapper-utils.ts
@@ -50,7 +50,7 @@ export function decodeResult(method: Method, hexString: string) {
 const constructJSONRPCParams = (
   address: string,
   method: Method,
-  gasInfo: number,
+  gasInfo?: number,
   methodParam?: string,
 ): JsonRpcEthereumProviderParamsWithLatest => {
   const data = methodParam
@@ -61,7 +61,7 @@ const constructJSONRPCParams = (
     {
       to: address,
       value: METHODS[method].value,
-      gas: numberToHex(gasInfo),
+      ...(gasInfo ? { gas: numberToHex(gasInfo) } : {}),
       data,
     },
     'latest',
@@ -71,7 +71,7 @@ const constructJSONRPCParams = (
 export function constructJSONRPC(
   address: string,
   method: Method,
-  gasInfo: number,
+  gasInfo?: number,
   methodParam?: string,
 ): JsonRpc {
   idCount += 1;

--- a/src/provider/providerWrapper.ts
+++ b/src/provider/providerWrapper.ts
@@ -158,7 +158,7 @@ export class ProviderWrapper {
         constructJSONRPC(
           address,
           Method.IS_VALID_SIGNATURE,
-          this.gas,
+          undefined, // this.gas,
           encodedParams,
         ),
       );
@@ -183,7 +183,7 @@ export class ProviderWrapper {
       constructJSONRPC(
         address,
         Method.IS_VALID_SIGNATURE,
-        this.gas,
+        undefined, // this.gas,
         encodedParams,
       ),
     ]);
@@ -245,7 +245,7 @@ export class ProviderWrapper {
         constructJSONRPC(
           address,
           method,
-          this.gas,
+          undefined, // this.gas,
           abiCoder.encodeParameter('bytes32[]', keyHashes),
         ),
       );
@@ -262,7 +262,7 @@ export class ProviderWrapper {
       constructJSONRPC(
         address,
         method,
-        this.gas,
+        undefined, // this.gas,
         abiCoder.encodeParameter('bytes32[]', keyHashes),
       ),
     ];

--- a/src/types/JsonRpc.ts
+++ b/src/types/JsonRpc.ts
@@ -1,6 +1,6 @@
 interface JsonRpcEthereumProviderParams {
   to: string;
-  gas: string;
+  gas?: string;
   value: string;
   data;
 }


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

- fix: Repair problems with IPFS, fetch and VerifiableURI
- fix: Repair to not throw errors when data is not authentica or not accessible withing getDataFromExternalSources.

### What is the current behaviour (you can also link to an open issue here)?

The current behavior is that when data is invalid or unreachable in ipfs. getDataFromExternalSource will throw an exception.

### What is the new behaviour (if this is a feature change)?

These are now converted to a console.error, allowing the data to return as "null". This allows getData to be called with multiple keys
including one that maybe invalid and not just throw out of the section of code.

### Other information:

I also made a similar kind of fix when the array length data (i.e. LSP12IssuedAssets[]) contains a uint256 instead of a uint128.
