### PR TITLE
fix: decoding tuple when no value is fetched

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -720,6 +720,56 @@ describe('Running @erc725/erc725.js tests...', () => {
           );
         });
       }
+
+      it('fetchData and return `[undefined...]` number of elements based on number of tuple elements', async () => {
+        const provider = new HttpProvider(
+          {
+            returnData: allRawData.filter(
+              (rawData) =>
+                rawData.key ===
+                '0xd154e1e44d32870ff5ade9e8726fd06d0ed6c996f5946dabfdfd46aa6dd2ea99',
+            ),
+          },
+          [contractVersion.interface],
+        );
+
+        const erc725js = new ERC725(
+          [
+            {
+              name: 'LSP4CreatorsMap:<address>',
+              key: '0x6de85eaf5d982b4e5da00000<address>',
+              keyType: 'Mapping',
+              valueType: '(bytes4,uint128)',
+              valueContent: '(Bytes4,Number)',
+            },
+            {
+              name: 'AnotherKeyWithTuple',
+              key: '0xe285b699bb64c38edb31f6be9fe25f8778b48b260430a16ea4d4cfd1d7ac6d38',
+              keyType: 'Singleton',
+              valueType: '(address,address,uint128,bytes4)',
+              valueContent: '(Address,Address,Number,Bytes)',
+            },
+          ],
+          address,
+          provider,
+        );
+
+        const result = await erc725js.fetchData([
+          'AnotherKeyWithTuple',
+          {
+            keyName: 'LSP4CreatorsMap:<address>',
+            dynamicKeyParts: '0x9139def55c73c12bcda9c44f12326686e3948634',
+          },
+        ]);
+
+        assert.deepStrictEqual(result[0].value, [
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+        ]);
+        // assert.deepStrictEqual(result[1].value, [undefined, undefined]);
+      });
     });
   });
 

--- a/src/lib/decodeData.ts
+++ b/src/lib/decodeData.ts
@@ -158,11 +158,13 @@ export const decodeTupleKeyValue = (
     0,
   );
 
-  if (value.length !== 2 + totalBytesLength * 2) {
+  // if value cannot be decoded, we return an array of as many `undefined`
+  // as the number of elements there is mentioned in the tuple definition.
+  if (!value || value.length !== 2 + totalBytesLength * 2) {
     console.error(
       `Trying to decode a value: ${value} which does not match the length of the valueType: ${valueType}. Expected ${totalBytesLength} bytes.`,
     );
-    return [];
+    return Array(valueTypeParts.length).fill(undefined);
   }
 
   let cursor = 2; // to skip the 0x


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

Bug fix

### What is the current behaviour (you can also link to an open issue here)?

See issue #372 

### What is the new behaviour (if this is a feature change)?

When using `getData` or `fetchData` with a key type that contains a tuple, if no value is fetched, return an array with a number of `undefined` elements (as many as defined by the number of elements in the tuple).

### Other information:

Fix #372 
