### PR TITLE
feat: allow to import TS typed schemas from `@erc725/erc725.js/schemas`

### DIFF
--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -20,9 +20,29 @@ _A quick reference for keys used in schema definitions can be seen below_
 
 ## Standard LSP Schemas
 
-The most common schemas of [LUKSO Standard Proposals](https://github.com/lukso-network/LIPs/tree/main/LSPs) are available under the [`schemas/`](https://github.com/ERC725Alliance/erc725.js/tree/develop/schemas) folder.
+The most common schemas of [LUKSO Standard Proposals](https://github.com/lukso-network/LIPs/tree/main/LSPs) are available to import. These are typed automatically with the Typescript type `ERC725JSONSchema[]` for when instantiating `new ERC725(...)` from Typescript projects.
 
-Current provided LSPs are:
+```ts
+import {
+  LSP1Schema,
+  LSP3Schema,
+  LSP4Schema,
+  LSP4LegacySchema,
+  LSP5Schema,
+  LSP6Schema,
+  LSP8Schema,
+  LSP9Schema,
+  LSP10Schema,
+  LSP12Schema,
+  LSP17Schema,
+} from '@erc725/erc725.js/schemas';
+
+const erc725js = new ERC725(LSP12Schema);
+```
+
+The raw JSON schemas are also available for import from the [`schemas/`](https://github.com/ERC725Alliance/erc725.js/tree/develop/schemas) folder.
+
+Current provided LSPs JSON schemas are:
 
 ```
 LSP1UniversalReceiverDelegate.json
@@ -38,7 +58,7 @@ LSP12IssuedAssets.json
 LSP17ContractExtension.json
 ```
 
-You can import them from:
+You can import the raw JSON as follow:
 
 ```js
 import LSP3 from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -24,6 +24,9 @@ import Web3 from 'web3';
 import * as sinon from 'sinon';
 import { hexToNumber, leftPad, numberToHex } from 'web3-utils';
 
+// examples of schemas to load (for testing)
+import { LSP1Schema, LSP12Schema, LSP3Schema, LSP6Schema } from './schemas';
+
 import ERC725 from '.';
 import {
   decodeKeyValue,
@@ -66,6 +69,18 @@ describe('Running @erc725/erc725.js tests...', () => {
       // eslint-disable-next-line no-new
       new ERC725(mockSchema, address, { test: false });
     }, /Incorrect or unsupported provider/);
+  });
+
+  it('should allow importing the schemas and instantiating with them', async () => {
+    const schemasToLoad = [
+      ...LSP1Schema,
+      ...LSP12Schema,
+      ...LSP3Schema,
+      ...LSP6Schema,
+    ];
+    const erc725 = new ERC725(schemasToLoad);
+
+    assert.deepStrictEqual(erc725.options.schemas, schemasToLoad);
   });
 
   it('should throw when calling getData without address & provider options set', async () => {

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,26 +1,27 @@
 import { ERC725JSONSchema } from '../types/ERC725JSONSchema';
 
-import LSP1UniversalReceiverDelegate from '../../schemas/LSP1UniversalReceiverDelegate.json';
-import LSP3Profile from '../../schemas/LSP3ProfileMetadata.json';
-import LSP4DigitalAssetLegacy from '../../schemas/LSP4DigitalAssetLegacy.json';
-import LSP4DigitalAsset from '../../schemas/LSP4DigitalAsset.json';
-import LSP5ReceivedAssets from '../../schemas/LSP5ReceivedAssets.json';
-import LSP6KeyManager from '../../schemas/LSP6KeyManager.json';
-import LSP8IdentifiableDigitalAsset from '../../schemas/LSP8IdentifiableDigitalAsset.json';
-import LSP9Vault from '../../schemas/LSP9Vault.json';
-import LSP10ReceivedVaults from '../../schemas/LSP10ReceivedVaults.json';
-import LSP12IssuedAssets from '../../schemas/LSP12IssuedAssets.json';
-import LSP17ContractExtension from '../../schemas/LSP17ContractExtension.json';
+import LSP1JSONSchema from '../../schemas/LSP1UniversalReceiverDelegate.json';
+import LSP3JSONSchema from '../../schemas/LSP3ProfileMetadata.json';
+import LSP4JSONSchema from '../../schemas/LSP4DigitalAsset.json';
+import LSP4LegacyJSONSchema from '../../schemas/LSP4DigitalAssetLegacy.json';
+import LSP5JSONSchema from '../../schemas/LSP5ReceivedAssets.json';
+import LSP6JSONSchema from '../../schemas/LSP6KeyManager.json';
+import LSP8JSONSchema from '../../schemas/LSP8IdentifiableDigitalAsset.json';
+import LSP9JSONSchema from '../../schemas/LSP9Vault.json';
+import LSP10JSONSchema from '../../schemas/LSP10ReceivedVaults.json';
+import LSP12JSONSchema from '../../schemas/LSP12IssuedAssets.json';
+import LSP17JSONSchema from '../../schemas/LSP17ContractExtension.json';
 
-export default LSP1UniversalReceiverDelegate.concat(
-  LSP3Profile,
-  LSP4DigitalAssetLegacy,
-  LSP4DigitalAsset,
-  LSP5ReceivedAssets,
-  LSP6KeyManager,
-  LSP8IdentifiableDigitalAsset,
-  LSP9Vault,
-  LSP10ReceivedVaults,
-  LSP12IssuedAssets,
-  LSP17ContractExtension,
-) as ERC725JSONSchema[];
+type schemaType = ERC725JSONSchema[];
+
+export const LSP1Schema: schemaType = LSP1JSONSchema as schemaType;
+export const LSP3Schema: schemaType = LSP3JSONSchema as schemaType;
+export const LSP4Schema: schemaType = LSP4JSONSchema as schemaType;
+export const LSP4LegacySchema: schemaType = LSP4LegacyJSONSchema as schemaType;
+export const LSP5Schema: schemaType = LSP5JSONSchema as schemaType;
+export const LSP6Schema: schemaType = LSP6JSONSchema as schemaType;
+export const LSP8Schema: schemaType = LSP8JSONSchema as schemaType;
+export const LSP9Schema: schemaType = LSP9JSONSchema as schemaType;
+export const LSP10Schema: schemaType = LSP10JSONSchema as schemaType;
+export const LSP12Schema: schemaType = LSP12JSONSchema as schemaType;
+export const LSP17Schema: schemaType = LSP17JSONSchema as schemaType;

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -25,3 +25,18 @@ export const LSP9Schema: schemaType = LSP9JSONSchema as schemaType;
 export const LSP10Schema: schemaType = LSP10JSONSchema as schemaType;
 export const LSP12Schema: schemaType = LSP12JSONSchema as schemaType;
 export const LSP17Schema: schemaType = LSP17JSONSchema as schemaType;
+
+const AllSchemas = LSP1Schema.concat(
+  LSP3Schema,
+  LSP4Schema,
+  LSP4LegacySchema,
+  LSP5Schema,
+  LSP6Schema,
+  LSP8Schema,
+  LSP9Schema,
+  LSP10Schema,
+  LSP12Schema,
+  LSP17Schema,
+);
+
+export default AllSchemas;

--- a/src/types/ERC725JSONSchema.ts
+++ b/src/types/ERC725JSONSchema.ts
@@ -159,7 +159,7 @@ export function isValidValueType(
 export interface ERC725JSONSchema {
   name: string; // Describes the name of the key, SHOULD compromise of the Standards name + sub type. e.g: LSP2Name
   key: string; // The keccak256 hash of the name. This is the actual key that MUST be retrievable via ERC725Y.getData(bytes32 key)
-  keyType: ERC725JSONSchemaKeyType; // Types that determine how the values should be interpreted.
+  keyType: ERC725JSONSchemaKeyType | string; // Types that determine how the values should be interpreted.
   valueContent: ERC725JSONSchemaValueContent | string; // string holds '0x1345ABCD...' If the value content are specific bytes, than the returned value is expected to equal those bytes.
   valueType: ERC725JSONSchemaValueType | string; // The type of the value. This is used to determine how the value should be encoded / decode (`string` for tuples and CompactBytesArray).
 }


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

Feature + Bug fix

### What is the current behaviour (you can also link to an open issue here)?

Currently when importing a schema from the `schemas/` folder, the typing breaks in Typescript projects. See the following error:

<img width="1091" alt="Screenshot 2024-01-22 at 16 31 41" src="https://github.com/ERC725Alliance/erc725.js/assets/31145285/bc2c7e18-4394-4461-a8a4-da8a3104fdfe">

In order to fix that, the project has to import the `ERC725JSONSchema` type and cast it with `as`.

```ts
import ERC725, { ERC725JSONSchema } from '@erc725/erc725.js';
import LSP6Schema from '@erc725/erc725.js/schemas/LSP6KeyManager.json';

// instantiate erc725.js
const erc725js = new ERC725(LSP6Schema as ERC725JSONSchema[]);
```

### What is the new behaviour (if this is a feature change)?

- Fix the problem above by add the `string` type to `keyType` property in `ERC725JSONSchema` type.
- Allow shorter imports by exporting all the available schemas from the `schemas/` folder. This enables to import typed schemas from the `schemas/` folder as shown below (instead of having to write multiple `import` statement for each schema JSON file.

```ts
import {
  LSP1Schema,
  LSP3Schema,
} from '@erc725/erc725.js/schemas';

const erc725js = new ERC725([...LSP12Schema, ...LSP3Schema]);
```

### Other information:

Improve on the issue #379 
