### PR TITLE
fix: Allow LF or TAB in the middle of JSON detection

### DIFF
--- a/src/lib/getDataFromExternalSources.ts
+++ b/src/lib/getDataFromExternalSources.ts
@@ -126,7 +126,7 @@ export const getDataFromExternalSources = (
             // Check if the beginning or end are
             // { and } => JSON.stringify({...}) => pretty much 100% of our JSON will be this.
             // [ and ] => JSON.stringify([...])
-            if (/^(\[.*\]|\{.*\})\s*$/.test(key)) {
+            if (/^(\[.*\]|\{.*\})\s*$/s.test(key)) {
               const json = arrToBufArr(receivedData).toString();
               const value = JSON.parse(json);
               if (isDataAuthentic(value, urlDataWithHash.verification)) {


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

Allow JSON detection to work if there is a LF right before and after the end.

### What is the current behaviour (you can also link to an open issue here)?

### What is the new behaviour (if this is a feature change)?

### Other information:
