### PR TITLE
feat: add dynamic array encoding for encodeData

### DIFF
--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -444,13 +444,13 @@ _Example 2: input `1122334455` encoded as `bytes4` --> will encode as `0x42e576f
 
 An array of objects containing the following properties:
 
-| Name                         | Type                                           | Description                                                                                                                                                      |
-| :--------------------------- | :--------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `keyName`                    | string                                         | Can be either the named key (i.e. `LSP3Profile`, `LSP12IssuedAssetsMap:<address>`) or the hashed key (with or without `0x` prefix, i.e. `0x5ef...` or `5ef...`). |
-| `dynamicKeyParts` (optional) | string or <br/> string[&nbsp;]                 | The dynamic parts of the `keyName` that will be used for encoding the key.                                                                                       |
-| `value`                      | string or <br/> string[&nbsp;] <br/> JSON todo | The value that should be encoded. Can be a string, an array of string or a JSON...                                                                               |
-| `startingIndex` (optional)   | number                                         | Starting index for `Array` types to encode a subset of elements. Defaults t `0`.                                                                                 |
-| `arrayLength` (optional)     | number                                         | Parameter for `Array` types, specifying the total length when encoding a subset of elements. Defaults to the number of elements in the `value` field.            |
+| Name                          | Type                                           | Description                                                                                                                                                      |
+| :---------------------------- | :--------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `keyName`                     | string                                         | Can be either the named key (i.e. `LSP3Profile`, `LSP12IssuedAssetsMap:<address>`) or the hashed key (with or without `0x` prefix, i.e. `0x5ef...` or `5ef...`). |
+| `dynamicKeyParts` (optional)  | string or <br/> string[&nbsp;]                 | The dynamic parts of the `keyName` that will be used for encoding the key.                                                                                       |
+| `value`                       | string or <br/> string[&nbsp;] <br/> JSON todo | The value that should be encoded. Can be a string, an array of string or a JSON...                                                                               |
+| `startingIndex` (optional)    | number                                         | Starting index for `Array` types to encode a subset of elements. Defaults t `0`.                                                                                 |
+| `totalArrayLength` (optional) | number                                         | Parameter for `Array` types, specifying the total length when encoding a subset of elements. Defaults to the number of elements in the `value` field.            |
 
 The `keyName` also supports dynamic keys for [`Mapping`](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#mapping) and [`MappingWithGrouping`](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#mapping). Therefore, you can use variables in the key name such as `LSP12IssuedAssetsMap:<address>`. In that case, the value should also set the `dynamicKeyParts` property:
 
@@ -716,18 +716,20 @@ const schemas = [
   },
 ];
 
-const myErc725 = new ERC725(schemas);
-myErc725.encodeData([
-  {
-    keyName: 'AddressPermissions[]',
-    value: [
-      '0x983abc616f2442bab7a917e6bb8660df8b01f3bf',
-      '0x56ecbc104136d00eb37aa0dce60e075f10292d81',
-    ],
-    arrayLength: 23,
-    startingIndex: 21,
-  },
-]);
+myErc725.encodeData(
+  [
+    {
+      keyName: 'AddressPermissions[]',
+      value: [
+        '0x983abc616f2442bab7a917e6bb8660df8b01f3bf',
+        '0x56ecbc104136d00eb37aa0dce60e075f10292d81',
+      ],
+      totalArrayLength: 23,
+      startingIndex: 21,
+    },
+  ],
+  schemas,
+);
 /**
 {
   keys: [

--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -449,6 +449,8 @@ An array of objects containing the following properties:
 | `keyName`                    | string                                         | Can be either the named key (i.e. `LSP3Profile`, `LSP12IssuedAssetsMap:<address>`) or the hashed key (with or without `0x` prefix, i.e. `0x5ef...` or `5ef...`). |
 | `dynamicKeyParts` (optional) | string or <br/> string[&nbsp;]                 | The dynamic parts of the `keyName` that will be used for encoding the key.                                                                                       |
 | `value`                      | string or <br/> string[&nbsp;] <br/> JSON todo | The value that should be encoded. Can be a string, an array of string or a JSON...                                                                               |
+| `startingIndex` (optional)   | number                                         | Starting index for `Array` types to encode a subset of elements. Defaults t `0`.                                                                                 |
+| `arrayLength` (optional)     | number                                         | Parameter for `Array` types, specifying the total length when encoding a subset of elements. Defaults to the number of elements in the `value` field.            |
 
 The `keyName` also supports dynamic keys for [`Mapping`](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#mapping) and [`MappingWithGrouping`](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#mapping). Therefore, you can use variables in the key name such as `LSP12IssuedAssetsMap:<address>`. In that case, the value should also set the `dynamicKeyParts` property:
 
@@ -694,6 +696,50 @@ myErc725.encodeData([
     '0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0',
   ],
   values: ['0x00000000000000000000000000000005'],
+}
+*/
+```
+
+</details>
+
+<details>
+    <summary>Encode a subset of array elements</summary>
+
+```javascript title="Encode a subset of array elements"
+const schemas = [
+  {
+    name: 'AddressPermissions[]',
+    key: '0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3',
+    keyType: 'Array',
+    valueType: 'address',
+    valueContent: 'Address',
+  },
+];
+
+const myErc725 = new ERC725(schemas);
+myErc725.encodeData([
+  {
+    keyName: 'AddressPermissions[]',
+    value: [
+      '0x983abc616f2442bab7a917e6bb8660df8b01f3bf',
+      '0x56ecbc104136d00eb37aa0dce60e075f10292d81',
+    ],
+    arrayLength: 23,
+    startingIndex: 21,
+  },
+]);
+/**
+{
+  keys: [
+    '0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3',
+    '0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000015', 
+    '0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000016',
+  ],
+  values: [
+    '0x00000000000000000000000000000017',
+    '0x983abc616f2442bab7a917e6bb8660df8b01f3bf',
+    '0x56ecbc104136d00eb37aa0dce60e075f10292d81',
+  ],
 }
 */
 ```
@@ -1611,7 +1657,7 @@ Either a string of the hexadecimal `interfaceID` as defined by [ERC165](https://
 
 The `interfaceName` will only check for the latest version of the standard's `interfaceID`, which can be found in `src/constants/interfaces`. For LSPs, the `interfaceIDs` are taken from the latest release of the [@lukso/lsp-smart-contracts](https://github.com/lukso-network/lsp-smart-contracts) library.
 
-:::info
+:::
 
 ##### 2. `options` - Object (optional)
 

--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -456,6 +456,24 @@ The `keyName` also supports dynamic keys for [`Mapping`](https://github.com/luks
 
 - `dynamicKeyParts`: string or string[&nbsp;] which holds the variables that needs to be encoded.
 
+:::info Handling array subsets
+
+The `totalArrayLength` parameter must be explicitly provided to ensure integrity when encoding subsets or modifying existing array elements. Its value specifies the total length of the array **after the operation is completed**, not just the size of the encoded subset.
+
+**When to Use `totalArrayLength`**
+
+- **Adding Elements:** When adding new elements to an array, `totalArrayLength` should equal the sum of the current array's length plus the number of new elements added.
+- **Modifying Elements:** If modifying elements within an existing array without changing the total number of elements, `totalArrayLength` should match the previous length of the array.
+- **Removing Elements:** In cases where elements are removed, `totalArrayLength` should reflect the number of elements left.
+
+:::
+
+:::caution Encoding array lengths
+
+Please be careful when updating existing contract data. Incorrect usage of `startingIndex` and `totalArrayLength` can lead to improperly encoded data that changes the intended structure of the data field.
+
+:::
+
 ##### 2. `schemas` - Array of Objects (optional)
 
 An array of extra [LSP-2 ERC725YJSONSchema] objects that can be used to find the schema. If called on an instance, it is optional and it will be concatenated with the schema provided on instantiation.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1022,12 +1022,12 @@ describe('Running @erc725/erc725.js tests...', () => {
                 '0x983abc616f2442bab7a917e6bb8660df8b01f3bf',
                 '0x56ecbc104136d00eb37aa0dce60e075f10292d81',
               ],
-              arrayLength: 23,
+              totalArrayLength: 23,
               startingIndex: 21,
             },
           ]);
 
-          // Expected result with custom startingIndex and arrayLength
+          // Expected result with custom startingIndex and totalArrayLength
           const expectedResult = {
             keys: [
               '0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1004,6 +1004,45 @@ describe('Running @erc725/erc725.js tests...', () => {
           assert.deepStrictEqual(results, intendedResult);
         });
 
+        it('encodes dynamic data values for keyType "Array" in naked class instance', () => {
+          const schemas: ERC725JSONSchema[] = [
+            {
+              name: 'AddressPermissions[]',
+              key: '0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3',
+              keyType: 'Array',
+              valueType: 'address',
+              valueContent: 'Address',
+            },
+          ];
+          const erc725 = new ERC725(schemas);
+          const encodedArraySection = erc725.encodeData([
+            {
+              keyName: 'AddressPermissions[]',
+              value: [
+                '0x983abc616f2442bab7a917e6bb8660df8b01f3bf',
+                '0x56ecbc104136d00eb37aa0dce60e075f10292d81',
+              ],
+              arrayLength: 23,
+              startingIndex: 21,
+            },
+          ]);
+
+          // Expected result with custom startingIndex and arrayLength
+          const expectedResult = {
+            keys: [
+              '0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3',
+              '0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000015', // 21
+              '0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000016', // 22
+            ],
+            values: [
+              '0x00000000000000000000000000000017', // 23
+              '0x983abc616f2442bab7a917e6bb8660df8b01f3bf',
+              '0x56ecbc104136d00eb37aa0dce60e075f10292d81',
+            ],
+          };
+          assert.deepStrictEqual(encodedArraySection, expectedResult);
+        });
+
         it(`decode all data values for keyType "Array" in naked class instance: ${schemaElement.name}`, async () => {
           const values = allGraphData.filter(
             (e) => e.key.slice(0, 34) === schemaElement.key.slice(0, 34),

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1004,7 +1004,7 @@ describe('Running @erc725/erc725.js tests...', () => {
           assert.deepStrictEqual(results, intendedResult);
         });
 
-        it('encodes dynamic data values for keyType "Array" in naked class instance', () => {
+        it('encodes subset of elements for keyType "Array" in naked class instance', () => {
           const schemas: ERC725JSONSchema[] = [
             {
               name: 'AddressPermissions[]',

--- a/src/lib/encoder.test.ts
+++ b/src/lib/encoder.test.ts
@@ -633,7 +633,7 @@ describe('encoder', () => {
       });
     });
 
-    describe('when encoding a value that exceeds the maximal lenght of bytes than its type', () => {
+    describe('when encoding a value that exceeds the maximal length of bytes than its type', () => {
       const validTestCases = [
         {
           valueType: 'bytes32',
@@ -796,13 +796,13 @@ describe('encoder', () => {
       });
 
       describe('when encoding uintN[CompactBytesArray]', () => {
-        it('should throw if trying to encode a value that exceeds the maximal lenght of bytes for this type', async () => {
+        it('should throw if trying to encode a value that exceeds the maximal length of bytes for this type', async () => {
           expect(() => {
             encodeValueType('uint8[CompactBytesArray]', [15, 178, 266]);
           }).to.throw('Hex uint8 value at index 2 does not fit in 1 bytes');
         });
 
-        it('should throw if trying to decode a value that exceeds the maximal lenght of bytes for this type', async () => {
+        it('should throw if trying to decode a value that exceeds the maximal length of bytes for this type', async () => {
           expect(() => {
             decodeValueType(
               'uint8[CompactBytesArray]',
@@ -813,7 +813,7 @@ describe('encoder', () => {
       });
 
       describe('when encoding bytesN[CompactBytesArray]', () => {
-        it('should throw if trying to encode a value that exceeds the maximal lenght of bytes for this type', async () => {
+        it('should throw if trying to encode a value that exceeds the maximal length of bytes for this type', async () => {
           expect(() => {
             encodeValueType('bytes4[CompactBytesArray]', [
               '0xe6520726',
@@ -824,7 +824,7 @@ describe('encoder', () => {
           }).to.throw('Hex bytes4 value at index 3 does not fit in 4 bytes');
         });
 
-        it('should throw if trying to decode a value that exceeds the maximal lenght of bytes for this type', async () => {
+        it('should throw if trying to decode a value that exceeds the maximal length of bytes for this type', async () => {
           expect(() => {
             decodeValueType(
               'bytes4[CompactBytesArray]',

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -785,7 +785,7 @@ describe('utils', () => {
 
       assert.throws(
         encodeDataWithNegativeStartingIndex,
-        /Invalid startingIndex/,
+        /Invalid `startingIndex`/,
         'Should throw an error for negative startingIndex',
       );
     });
@@ -810,7 +810,7 @@ describe('utils', () => {
 
       assert.throws(
         encodeDataWithLowerTotalArrayLength,
-        /Invalid totalArrayLength/,
+        /Invalid `totalArrayLength`/,
         'Should throw an error for totalArrayLength smaller than the number of provided elements',
       );
     });

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -740,14 +740,14 @@ describe('utils', () => {
               '0x983abc616f2442bab7a917e6bb8660df8b01f3bf',
               '0x56ecbc104136d00eb37aa0dce60e075f10292d81',
             ],
-            arrayLength: 23,
+            totalArrayLength: 23,
             startingIndex: 21,
           },
         ],
         schemas,
       );
 
-      // Expected result with custom startingIndex and arrayLength
+      // Expected result with custom startingIndex and totalArrayLength
       const expectedResult = {
         keys: [
           '0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3',
@@ -775,7 +775,7 @@ describe('utils', () => {
             {
               keyName: 'AddressPermissions[]',
               value: ['0x983abc616f2442bab7a917e6bb8660df8b01f3bf'],
-              arrayLength: 1,
+              totalArrayLength: 1,
               startingIndex: -1,
             },
           ],
@@ -790,8 +790,8 @@ describe('utils', () => {
       );
     });
 
-    it('should throw if arrayLength is smaller than elements in provided value array', () => {
-      const encodeDataWithLowerArrayLength = () => {
+    it('should throw if totalArrayLength is smaller than elements in provided value array', () => {
+      const encodeDataWithLowerTotalArrayLength = () => {
         encodeData(
           [
             {
@@ -800,7 +800,7 @@ describe('utils', () => {
                 '0x983abc616f2442bab7a917e6bb8660df8b01f3bf',
                 '0x56ecbc104136d00eb37aa0dce60e075f10292d81',
               ],
-              arrayLength: 1, // 2 elements
+              totalArrayLength: 1, // 2 elements
               startingIndex: 0,
             },
           ],
@@ -809,9 +809,9 @@ describe('utils', () => {
       };
 
       assert.throws(
-        encodeDataWithLowerArrayLength,
-        /Invalid arrayLength/,
-        'Should throw an error for arrayLength smaller than the number of provided elements',
+        encodeDataWithLowerTotalArrayLength,
+        /Invalid totalArrayLength/,
+        'Should throw an error for totalArrayLength smaller than the number of provided elements',
       );
     });
 
@@ -821,7 +821,7 @@ describe('utils', () => {
           {
             keyName: 'AddressPermissions[]',
             value: ['0x983abc616f2442bab7a917e6bb8660df8b01f3bf'],
-            arrayLength: 1,
+            totalArrayLength: 1,
           },
         ],
         schemas,
@@ -845,7 +845,7 @@ describe('utils', () => {
       );
     });
 
-    it('should use the number of elements in value field if arrayLength is not provided', () => {
+    it('should use the number of elements in value field if totalArrayLength is not provided', () => {
       const result = encodeData(
         [
           {
@@ -854,7 +854,7 @@ describe('utils', () => {
               '0x983abc616f2442bab7a917e6bb8660df8b01f3bf',
               '0x56ecbc104136d00eb37aa0dce60e075f10292d81',
             ],
-            // Not specifying arrayLength, it should default to the number of elements in the value array
+            // Not specifying totalArrayLength, it should default to the number of elements in the value array
             startingIndex: 0,
           },
         ],
@@ -877,7 +877,7 @@ describe('utils', () => {
       assert.deepStrictEqual(
         result,
         expectedResult,
-        'should use the number of elements in value field if arrayLength is not provided',
+        'should use the number of elements in value field if totalArrayLength is not provided',
       );
     });
   });

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -791,7 +791,7 @@ describe('utils', () => {
     });
 
     it('should throw if arrayLength is smaller than elements in provided value array', () => {
-      const encodeDataWithLowerArrayLenght = () => {
+      const encodeDataWithLowerArrayLength = () => {
         encodeData(
           [
             {
@@ -809,7 +809,7 @@ describe('utils', () => {
       };
 
       assert.throws(
-        encodeDataWithLowerArrayLenght,
+        encodeDataWithLowerArrayLength,
         /Invalid arrayLength/,
         'Should throw an error for arrayLength smaller than the number of provided elements',
       );

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -262,13 +262,12 @@ export function encodeKey(
         return null;
       }
 
-      // Check if an starting index and array lenght are correct types
       if (
         typeof startingIndex !== 'number' ||
         typeof arrayLength !== 'number'
       ) {
         throw new Error(
-          'Invalid startingIndex or arrayLength parameters. Values must be of type number',
+          'Invalid startingIndex or arrayLength parameters. Values must be of type number.',
         );
       }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -244,7 +244,7 @@ export function encodeKey(
     | URLDataToEncode[]
     | boolean,
   startingIndex = 0,
-  arrayLength = Array.isArray(value) ? value.length : 0,
+  totalArrayLength = Array.isArray(value) ? value.length : 0,
 ) {
   // NOTE: This will not guarantee order of array as on chain. Assumes developer must set correct order
 
@@ -264,10 +264,10 @@ export function encodeKey(
 
       if (
         typeof startingIndex !== 'number' ||
-        typeof arrayLength !== 'number'
+        typeof totalArrayLength !== 'number'
       ) {
         throw new Error(
-          'Invalid startingIndex or arrayLength parameters. Values must be of type number.',
+          'Invalid startingIndex or totalArrayLength parameters. Values must be of type number.',
         );
       }
 
@@ -277,9 +277,9 @@ export function encodeKey(
         );
       }
 
-      if (arrayLength < value.length) {
+      if (totalArrayLength < value.length) {
         throw new Error(
-          'Invalid arrayLength parameter. Array length must be at least as large as the number of elements of the value array.',
+          'Invalid totalArrayLength parameter. Array length must be at least as large as the number of elements of the value array.',
         );
       }
 
@@ -287,12 +287,12 @@ export function encodeKey(
 
       for (let index = 0; index < value.length; index++) {
         if (index === 0) {
-          // This is arrayLength as the first element in the raw array
+          // This is totalArrayLength as the first element in the raw array
           // encoded as uint128
           results.push({
             key: schema.key,
             // Encode the explicitly provided or default array length
-            value: encodeValueType('uint128', arrayLength),
+            value: encodeValueType('uint128', totalArrayLength),
           });
         }
 
@@ -467,7 +467,7 @@ export function encodeData(
   return dataAsArray.reduce(
     (
       accumulator,
-      { keyName, value, dynamicKeyParts, startingIndex, arrayLength },
+      { keyName, value, dynamicKeyParts, startingIndex, totalArrayLength },
     ) => {
       let schemaElement: ERC725JSONSchema | null = null;
       let encodedValue; // would be nice to type this
@@ -486,7 +486,7 @@ export function encodeData(
           schemaElement,
           value,
           startingIndex,
-          arrayLength,
+          totalArrayLength,
         );
       } else {
         schemaElement = getSchemaElement(schema, keyName);
@@ -494,7 +494,7 @@ export function encodeData(
           schemaElement,
           value as any,
           startingIndex,
-          arrayLength,
+          totalArrayLength,
         );
       }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -267,19 +267,19 @@ export function encodeKey(
         typeof totalArrayLength !== 'number'
       ) {
         throw new Error(
-          'Invalid startingIndex or totalArrayLength parameters. Values must be of type number.',
+          'Invalid `startingIndex` or `totalArrayLength` parameters. Values must be of type number.',
         );
       }
 
       if (startingIndex < 0) {
         throw new Error(
-          'Invalid startingIndex parameter. Value cannot be negative.',
+          'Invalid `startingIndex` parameter. Value cannot be negative.',
         );
       }
 
       if (totalArrayLength < value.length) {
         throw new Error(
-          'Invalid totalArrayLength parameter. Array length must be at least as large as the number of elements of the value array.',
+          'Invalid `totalArrayLength` parameter. Array length must be at least as large as the number of elements of the value array.',
         );
       }
 

--- a/src/types/decodeData.ts
+++ b/src/types/decodeData.ts
@@ -4,7 +4,7 @@ export interface DataInput {
   keyName: string; // can be the name or the hex/hash
   value;
   dynamicKeyParts?: string | string[];
-  arrayLength?: number;
+  totalArrayLength?: number;
   startingIndex?: number;
 }
 

--- a/src/types/decodeData.ts
+++ b/src/types/decodeData.ts
@@ -4,6 +4,8 @@ export interface DataInput {
   keyName: string; // can be the name or the hex/hash
   value;
   dynamicKeyParts?: string | string[];
+  arrayLength?: number;
+  startingIndex?: number;
 }
 
 export interface EncodeDataInput extends DataInput {


### PR DESCRIPTION
### What kind of change does this PR introduce?

**Feature**: Dynamically encode ERC725 storage keys of type **Array**.

### What is the current behavior?

The library only allows users to define the full array they want to encode and set to a contract. For updates, developers must read through all existing elements and pay the gas for re-setting elements in the list, even if only a few of them are actually updated. This is highly impractical. 

### What is the new behavior?

Within the **encodeData(...)** function, developers can define a **startingIndex** and an **arrayLenght** parameter to dynamically adjust the output, which can be used for more gradient storage updates. Both parameters are optional. If not provided, the encoding falls back to the default behavior as before, starting from index 0 and using the length of the provided elements in the array.
