### PR TITLE
docs: Fix typos & grammar in class documentation

### DIFF
--- a/docs/classes/ERC725.md
+++ b/docs/classes/ERC725.md
@@ -18,7 +18,7 @@ Check if the required permissions are included in the granted permissions as def
 
 :::info
 
-`checkPermissions` is available as either a static or non-static method so can be called without instantiating an ERC725 object.
+`checkPermissions` is available as either a static or non-static method, so it can be called without instantiating an ERC725 object.
 
 :::
 
@@ -92,7 +92,7 @@ myErc725.decodeData(data [, schemas]);
 ERC725.decodeData(data, schemas);
 ```
 
-If you are reading the key-value store from an ERC725 smart-contract you can use the `decodeData` function to do the decoding for you.
+If you are reading the key-value store from an ERC725 smart contract you can use the `decodeData` function to do the decoding for you.
 
 :::tip
 If you want total convenience, it is recommended to use the [`fetchData`](ERC725.md#fetchdata) function, which automatically `decodes` and `fetches` external references.
@@ -108,7 +108,7 @@ An object or array of objects containing the following properties:
 | :--------------------------- | :----------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `keyName`                    | string                         | Can be either the named key (i.e. `LSP3Profile`, `LSP12IssuedAssetsMap:<address>`) or the hashed key (with or without `0x` prefix, i.e. `0x5ef...` or `5ef...`). |
 | `dynamicKeyParts` (optional) | string or <br/> string[&nbsp;] | If `keyName` is a dynamic key, the dynamic parts of the `keyName` that will be used for encoding the key.                                                        |
-| `value`                      | string or <br/> string[&nbsp;] | The value that should be decoded. Can be a string, an array of string or a JSON...                                                                               |
+| `value`                      | string or <br/> string[&nbsp;] | The value that should be decoded. Can be a string, an array of string, or a JSON.                                                                                |
 
 The `keyName` also supports dynamic keys for [`Mapping`](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#mapping) and [`MappingWithGrouping`](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#mapping). Therefore, you can use variables in the key name such as `LSP12IssuedAssetsMap:<address>`. In that case, the value should also set the `dynamicKeyParts` property:
 
@@ -116,7 +116,7 @@ The `keyName` also supports dynamic keys for [`Mapping`](https://github.com/luks
 
 ##### 2. `schemas` - Array of Objects (optional)
 
-An array of extra [LSP-2 ERC725YJSONSchema] objects that can be used to find the schema. If called on an instance, it is optional and it will be concatenated with the schema provided on instantiation.
+An array of extra [LSP-2 ERC725YJSONSchema] objects that can be used to find the schema. If called on an instance, the parameter is optional and will be concatenated with the schema provided on instantiation.
 
 #### Returns
 
@@ -285,7 +285,7 @@ Decodes permissions from hexadecimal defined by the [LSP6 KeyManager Standard](h
 
 :::info
 
-`decodePermissions` is available as either a static or non-static method so can be called without instantiating an ERC725 object.
+`decodePermissions` is available as either a static or non-static method, so it can be called without instantiating an ERC725 object.
 
 :::
 
@@ -444,13 +444,13 @@ _Example 2: input `1122334455` encoded as `bytes4` --> will encode as `0x42e576f
 
 An array of objects containing the following properties:
 
-| Name                          | Type                                           | Description                                                                                                                                                      |
-| :---------------------------- | :--------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `keyName`                     | string                                         | Can be either the named key (i.e. `LSP3Profile`, `LSP12IssuedAssetsMap:<address>`) or the hashed key (with or without `0x` prefix, i.e. `0x5ef...` or `5ef...`). |
-| `dynamicKeyParts` (optional)  | string or <br/> string[&nbsp;]                 | The dynamic parts of the `keyName` that will be used for encoding the key.                                                                                       |
-| `value`                       | string or <br/> string[&nbsp;] <br/> JSON todo | The value that should be encoded. Can be a string, an array of string or a JSON...                                                                               |
-| `startingIndex` (optional)    | number                                         | Starting index for `Array` types to encode a subset of elements. Defaults t `0`.                                                                                 |
-| `totalArrayLength` (optional) | number                                         | Parameter for `Array` types, specifying the total length when encoding a subset of elements. Defaults to the number of elements in the `value` field.            |
+| Name                          | Type                                      | Description                                                                                                                                                      |
+| :---------------------------- | :---------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `keyName`                     | string                                    | Can be either the named key (i.e. `LSP3Profile`, `LSP12IssuedAssetsMap:<address>`) or the hashed key (with or without `0x` prefix, i.e. `0x5ef...` or `5ef...`). |
+| `dynamicKeyParts` (optional)  | string or <br/> string[&nbsp;]            | The dynamic parts of the `keyName` that will be used for encoding the key.                                                                                       |
+| `value`                       | string or <br/> string[&nbsp;] <br/> JSON | The value that should be encoded. Can be a string, an array of string, or a JSON.                                                                                |
+| `startingIndex` (optional)    | number                                    | Starting index for `Array` types to encode a subset of elements. Defaults to `0`.                                                                                |
+| `totalArrayLength` (optional) | number                                    | Parameter for `Array` types, specifying the total length when encoding a subset of elements. Defaults to the number of elements in the `value` field.            |
 
 The `keyName` also supports dynamic keys for [`Mapping`](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#mapping) and [`MappingWithGrouping`](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#mapping). Therefore, you can use variables in the key name such as `LSP12IssuedAssetsMap:<address>`. In that case, the value should also set the `dynamicKeyParts` property:
 
@@ -778,7 +778,7 @@ Encodes permissions into a hexadecimal string as defined by the [LSP6 KeyManager
 
 :::info
 
-`encodePermissions` is available as either a static or non-static method so can be called without instantiating an ERC725 object.
+`encodePermissions` is available as either a static or non-static method, so it can be called without instantiating an ERC725 object.
 
 :::
 
@@ -786,7 +786,7 @@ Encodes permissions into a hexadecimal string as defined by the [LSP6 KeyManager
 
 ##### 1. `permissions` - Object
 
-An object with [LSP6 KeyManager Permissions] as keys and a `boolean` as value. Any ommited permissions will default to `false`.
+An object with [LSP6 KeyManager Permissions] as keys and a `boolean` as value. Any omitted permissions will default to `false`.
 
 #### Returns
 
@@ -825,7 +825,7 @@ ERC725.encodePermissions({
 }),
 // '0x0000000000000000000000000000000000000000000000000000000000000110'
 
-// Any ommited Permissions will default to false
+// Any omitted Permissions will default to false
 ERC725.encodePermissions({
   ADDCONTROLLER: true,
   ADDEXTENSIONS: true,
@@ -927,7 +927,7 @@ Hashes a key name for use on an [ERC725Y contract](https://github.com/ethereum/E
 
 :::info
 
-`encodeKeyName` is available as either a static or non-static method so can be called without instantiating an ERC725 object.
+`encodeKeyName` is available as either a static or non-static method, so it can be called without instantiating an ERC725 object.
 
 :::
 
@@ -988,7 +988,7 @@ Decode the values of the dynamic parts of a hashed key used on an [ERC725Y contr
 
 :::info
 
-`decodeMappingKey` is available as either a static or non-static method so can be called without instantiating an ERC725 object.
+`decodeMappingKey` is available as either a static or non-static method, so it can be called without instantiating an ERC725 object.
 
 :::
 
@@ -1088,9 +1088,9 @@ If you get the `ReferenceError: fetch is not defined` error, you need to install
 
 #### Parameters
 
-##### 1. `keys` - String, Object or array of Strings or/and Objects (optional)
+##### 1. `keys` - String, Object, or array of Strings or/and Objects (optional)
 
-The name(s) (or the encoded name(s) as schema key) of the element(s) in the smart contract's schema. If no keys are set, it will fetch all the non dynamic schema keys given at instantiation. For dynamic keys, you can use the object below:
+The name(s) (or the encoded name(s) as schema key) of the element(s) in the smart contract's schema. If no keys are set, it will fetch all the non-dynamic schema keys given at instantiation. For dynamic keys, you can use the object below:
 
 | Name              | Type                           | Description                                                                |
 | :---------------- | :----------------------------- | :------------------------------------------------------------------------- |
@@ -1099,9 +1099,9 @@ The name(s) (or the encoded name(s) as schema key) of the element(s) in the smar
 
 #### Returns
 
-| Name | Type                                        | Description                                                                                                                                                                                                                     |
-| :--- | :------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| data | `Promise<Array>` or <br/> `Promise<Object>` | An array with same objects as for [`decodeData()`](./ERC725#decodedata) function but with the value being remplaced by the actual file for `VerifiableURI` valueContent. If there is a hash mismatch, the value will be `null`. |
+| Name | Type                                        | Description                                                                                                                                                                                                                    |
+| :--- | :------------------------------------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data | `Promise<Array>` or <br/> `Promise<Object>` | An array with same objects as for [`decodeData()`](./ERC725#decodedata) function but with the value being replaced by the actual file for `VerifiableURI` valueContent. If there is a hash mismatch, the value will be `null`. |
 
 :::info
 
@@ -1236,9 +1236,9 @@ When omitting the `keys` parameter, it will give back every key (as per `ERC725J
 
 #### Parameters
 
-##### 1. `keys` - String, Object or array of Strings or/and Objects (optional)
+##### 1. `keys` - String, Object, or array of Strings or/and Objects (optional)
 
-The name(s) (or the encoded name(s) as schema key) of the element(s) in the smart contract's schema. If no keys are set, it will fetch all the non dynamic schema keys given at instantiation. For dynamic keys, you can use the object below:
+The name(s) (or the encoded name(s) as schema key) of the element(s) in the smart contract's schema. If no keys are set, it will fetch all the non-dynamic schema keys given at instantiation. For dynamic keys, you can use the object below:
 
 | Name              | Type                           | Description                                                                |
 | :---------------- | :----------------------------- | :------------------------------------------------------------------------- |
@@ -1247,9 +1247,9 @@ The name(s) (or the encoded name(s) as schema key) of the element(s) in the smar
 
 #### Returns
 
-| Name | Type                                        | Description                                                                       |
-| :--- | :------------------------------------------ | :-------------------------------------------------------------------------------- |
-| data | `Promise<Array>` or <br/> `Promise<Object>` | An array with same objects as for [`decodeData()`](./ERC725#decodedata) function. |
+| Name | Type                                        | Description                                                                           |
+| :--- | :------------------------------------------ | :------------------------------------------------------------------------------------ |
+| data | `Promise<Array>` or <br/> `Promise<Object>` | An array with the same objects as for [`decodeData()`](./ERC725#decodedata) function. |
 
 :::info
 
@@ -1452,7 +1452,7 @@ Returns the contract owner and is not directly related to ERC725 specifications.
 
 ##### 1. `address` - String (optional)
 
-The contract address you wish to find the owner of. If no address is set, will return the owner of the contract used to initialise the ERC725 class.
+The contract address you wish to find the owner of. If no address is set, it will return the owner of the contract used to initialize the ERC725 class.
 
 #### Returns
 
@@ -1469,7 +1469,7 @@ The address of the contract owner as stored in the contract.
 #### Example
 
 ```javascript title="Receiving the owner address"
-// If no address is set, it will return the owner of the contract used to initialise the ERC725() class.
+// If no address is set, it will return the owner of the contract used to initialize the ERC725() class.
 await myErc725.getOwner();
 // '0x94933413384997F9402cc07a650e8A34d60F437A'
 
@@ -1489,7 +1489,7 @@ myErc725.getSchema(keys [, providedSchemas]);
 Parses a hashed key or a list of hashed keys and will attempt to return its corresponding [LSP2 ERC725YJSONSchema](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md) object. Additionally, it will look for a corresponding key within the schemas:
 
 - in the [`schemas`](https://github.com/ERC725Alliance/myErc725.js/tree/main/schemas) folder (which includes all [LSPs](https://github.com/lukso-network/LIPs/tree/main/LSPs)),
-- that were provided at ERC725 initialisation, and
+- that were provided at ERC725 initialization, and
 - that were provided in the function call (`providedSchemas`).
 
 #### Parameters
@@ -1597,7 +1597,7 @@ The raw RLP encoded signature.
 
 :::info
 
-- The hash must be 66 chars long with the `0x` prefix, otherwise it will be interpreded as message.
+- The hash must be 66 chars long with the `0x` prefix. Otherwise, it will be interpreted as message.
 - The message will be: enveloped as `"\x19Ethereum Signed Message:\n" + message.length + message` and hashed using `keccak256` function.
   The signature can be generated with [`web3.eth.accounts.sign()`](https://web3js.readthedocs.io/en/v1.2.11/web3-eth-accounts.html#sign).
 
@@ -1648,7 +1648,7 @@ myERC725.supportsInterface(interfaceIdOrName);
 ERC725.supportsInterface(interfaceIdOrName, options);
 ```
 
-You can use this function if you need to check if the ERC725 object or a smart contract supports a specific interface (by ID or name). When you use the function on your instantiated ERC725 class, it will use the contract address and provider provided at instantiation. On non instantiated class, you need to specify them in the `options` parameter.
+You can use this function if you need to check if the ERC725 object or a smart contract supports a specific interface (by ID or name). When you use the function on your instantiated ERC725 class, it will use the contract address and provider provided at instantiation. On a non-instantiated class, you need to specify them in the `options` parameter.
 
 :::caution
 The `interfaceId` is not the most secure way to check for a standard, as they could be set manually.


### PR DESCRIPTION
This PR fixes some grammar that I noticed when reading through the documentation. It also removes a left-over TODO.