### PR TITLE
fix: Filter out ALL_PERMISSIONS from keys in LSP6_DEFAULT_PERMISSIONS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,166 +4,149 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [0.24.0](https://github.com/ERC725Alliance/erc725.js/compare/v0.23.1...v0.24.0) (2024-04-02)
 
-
 ### Features
 
-* add dynamic array encoding ([f0f495c](https://github.com/ERC725Alliance/erc725.js/commit/f0f495c69e8b4768468437cad24f1b77d53a379f))
-* replace dynamic part with hex value when parsing schemas for `Mapping` keys ([a9fdb4d](https://github.com/ERC725Alliance/erc725.js/commit/a9fdb4daa69e2aac38aca2393f94e8fe83113656))
-
+- add dynamic array encoding ([f0f495c](https://github.com/ERC725Alliance/erc725.js/commit/f0f495c69e8b4768468437cad24f1b77d53a379f))
+- replace dynamic part with hex value when parsing schemas for `Mapping` keys ([a9fdb4d](https://github.com/ERC725Alliance/erc725.js/commit/a9fdb4daa69e2aac38aca2393f94e8fe83113656))
 
 ### Bug Fixes
 
-* Patch full pretty printed with LF and TAB. ([315fa54](https://github.com/ERC725Alliance/erc725.js/commit/315fa547ab8f2d25db4f771d818afeec0d324bdf))
+- Patch full pretty printed with LF and TAB. ([315fa54](https://github.com/ERC725Alliance/erc725.js/commit/315fa547ab8f2d25db4f771d818afeec0d324bdf))
 
 ## [0.23.1](https://github.com/ERC725Alliance/erc725.js/compare/v0.23.0...v0.23.1) (2024-02-23)
 
-
 ### Bug Fixes
 
-* Add check for pretty printed and non-pretty printed versions of JSON ([aa68bf1](https://github.com/ERC725Alliance/erc725.js/commit/aa68bf132d2e4793b4da784c30ae8f306560da8c))
-* Missing line ([d13be00](https://github.com/ERC725Alliance/erc725.js/commit/d13be00ba77be924f914cba1283e9c37250ec9bd))
-* Re-do PR with minimal changes ([17458d6](https://github.com/ERC725Alliance/erc725.js/commit/17458d623f214f026307184357bcf7ff75fad7ed))
-* Repair package-lock to be just as on main ([e793246](https://github.com/ERC725Alliance/erc725.js/commit/e793246e7e09bd80628f19499a5218ce70df8401))
+- Add check for pretty printed and non-pretty printed versions of JSON ([aa68bf1](https://github.com/ERC725Alliance/erc725.js/commit/aa68bf132d2e4793b4da784c30ae8f306560da8c))
+- Missing line ([d13be00](https://github.com/ERC725Alliance/erc725.js/commit/d13be00ba77be924f914cba1283e9c37250ec9bd))
+- Re-do PR with minimal changes ([17458d6](https://github.com/ERC725Alliance/erc725.js/commit/17458d623f214f026307184357bcf7ff75fad7ed))
+- Repair package-lock to be just as on main ([e793246](https://github.com/ERC725Alliance/erc725.js/commit/e793246e7e09bd80628f19499a5218ce70df8401))
 
 ## [0.23.0](https://github.com/ERC725Alliance/erc725.js/compare/v0.22.0...v0.23.0) (2024-01-22)
 
-
 ### Features
 
-* add permission related to 4337 ([e7fd19b](https://github.com/ERC725Alliance/erc725.js/commit/e7fd19bc27aa89fae410b9633ef5ccdf13f33f0e))
-* allow to load typed schemas from `schemas/` folder ([c54a370](https://github.com/ERC725Alliance/erc725.js/commit/c54a370c1e4f8d71ba6bb7e62122b89069f521e6))
-
+- add permission related to 4337 ([e7fd19b](https://github.com/ERC725Alliance/erc725.js/commit/e7fd19bc27aa89fae410b9633ef5ccdf13f33f0e))
+- allow to load typed schemas from `schemas/` folder ([c54a370](https://github.com/ERC725Alliance/erc725.js/commit/c54a370c1e4f8d71ba6bb7e62122b89069f521e6))
 
 ### Bug Fixes
 
-* Add workaround to read (bytes4,URI), repair none vs unknown signature. ([204409d](https://github.com/ERC725Alliance/erc725.js/commit/204409df544825041a586865cfb6bb124288e48f))
-* Additional PR repair ([2a18f2b](https://github.com/ERC725Alliance/erc725.js/commit/2a18f2bf1a24547e71cad6953f5144761aa2cc9a))
-* BodyInit should be just string or buffer and not already Uint8Array ([08e0177](https://github.com/ERC725Alliance/erc725.js/commit/08e017778fa42ade5386b8d9e85255225a7f3195))
-* Cleanup ([038d975](https://github.com/ERC725Alliance/erc725.js/commit/038d97584075c89f93f51227666074cf11973a29))
-* Cleanup a bit with comments. ([3d6a5a6](https://github.com/ERC725Alliance/erc725.js/commit/3d6a5a65db5049b678d0d54149e9b11ea2479999))
-* Cleanup and handle situation where one of many keys fails. Return null. ([cdf4583](https://github.com/ERC725Alliance/erc725.js/commit/cdf4583c159d8c8e52a832bfe5af6b650d8945fa))
-* Cleanup error handler inside of getDataFromExternalSources ([fde2e0f](https://github.com/ERC725Alliance/erc725.js/commit/fde2e0f41df3ecee90a4dfd8248dd9c2a7a72965))
-* Debug and repair test scripts. Implement detecting of JSON inside of Uint8Array ([74c0526](https://github.com/ERC725Alliance/erc725.js/commit/74c0526e3f544400ced78f02ff4fed64bd048bfa))
-* Missing commit ([a3dd604](https://github.com/ERC725Alliance/erc725.js/commit/a3dd604964c9c9221ff421fe668faa8fd363101a))
-* More fixes ([620b606](https://github.com/ERC725Alliance/erc725.js/commit/620b60632e50ca59abedae9935f8b75d188278e0))
-* Remove .only call for testing. ([d5ef3c9](https://github.com/ERC725Alliance/erc725.js/commit/d5ef3c9965e2c5ad343f88a9c30a6281e9fa169b))
-* Remove console debugging. ([e349d57](https://github.com/ERC725Alliance/erc725.js/commit/e349d5715c7779c1eeb8d6e08c3ae3bf17eedd9e))
-* Remove unnecessary special case for 0x00000000 ([cd6152a](https://github.com/ERC725Alliance/erc725.js/commit/cd6152a88ca7a1c98184799b6fdc6982ff8a1cd6))
-* Repair and enhance test scripts ([224eb9e](https://github.com/ERC725Alliance/erc725.js/commit/224eb9ecb1b16f373f2ad17ee9d3efab08dda53b))
-* Repair as per PR review ([0a52452](https://github.com/ERC725Alliance/erc725.js/commit/0a5245230455324e9911e4e14992c50e6f645ba2))
-* Repair console.log and expand types of URLs (ar://, ipfs://, https\?://, data:) ([5c8f228](https://github.com/ERC725Alliance/erc725.js/commit/5c8f2285d2d23c59ef9707a54e419b55d25e4136))
-* Repair problems with IPFS, fetch and VerifiableURI ([44834b8](https://github.com/ERC725Alliance/erc725.js/commit/44834b8ed517e869ad99920b2853e30213a8d7b5))
-* Repair to not throw errors when data is not authentica or not accessible withing getDataFromExternalSources. ([25756d0](https://github.com/ERC725Alliance/erc725.js/commit/25756d09cecfec5d13d6e4fb6ed842c4e3d77734))
-* Repair tuples containing numeric types uintX/intX, add Number to output data type. ([01cceea](https://github.com/ERC725Alliance/erc725.js/commit/01cceeac03f719df6eb8be8c238aca4483e7a3e8))
-* Simplify buffer to string conversion. ([0bd1349](https://github.com/ERC725Alliance/erc725.js/commit/0bd1349f863283cf16cc6808bef48990ec118361))
-* Simplify creation of key to detect JSON. ([df2580d](https://github.com/ERC725Alliance/erc725.js/commit/df2580d9434dc386480f7eec2cd6e94a5b4ca7c1))
-* Use a single keccak function since ethereumjs converts it to a Buffer no matter what. ([cdc6c0a](https://github.com/ERC725Alliance/erc725.js/commit/cdc6c0a0f749209352d620db6d60865a276e072c))
+- Add workaround to read (bytes4,URI), repair none vs unknown signature. ([204409d](https://github.com/ERC725Alliance/erc725.js/commit/204409df544825041a586865cfb6bb124288e48f))
+- Additional PR repair ([2a18f2b](https://github.com/ERC725Alliance/erc725.js/commit/2a18f2bf1a24547e71cad6953f5144761aa2cc9a))
+- BodyInit should be just string or buffer and not already Uint8Array ([08e0177](https://github.com/ERC725Alliance/erc725.js/commit/08e017778fa42ade5386b8d9e85255225a7f3195))
+- Cleanup ([038d975](https://github.com/ERC725Alliance/erc725.js/commit/038d97584075c89f93f51227666074cf11973a29))
+- Cleanup a bit with comments. ([3d6a5a6](https://github.com/ERC725Alliance/erc725.js/commit/3d6a5a65db5049b678d0d54149e9b11ea2479999))
+- Cleanup and handle situation where one of many keys fails. Return null. ([cdf4583](https://github.com/ERC725Alliance/erc725.js/commit/cdf4583c159d8c8e52a832bfe5af6b650d8945fa))
+- Cleanup error handler inside of getDataFromExternalSources ([fde2e0f](https://github.com/ERC725Alliance/erc725.js/commit/fde2e0f41df3ecee90a4dfd8248dd9c2a7a72965))
+- Debug and repair test scripts. Implement detecting of JSON inside of Uint8Array ([74c0526](https://github.com/ERC725Alliance/erc725.js/commit/74c0526e3f544400ced78f02ff4fed64bd048bfa))
+- Missing commit ([a3dd604](https://github.com/ERC725Alliance/erc725.js/commit/a3dd604964c9c9221ff421fe668faa8fd363101a))
+- More fixes ([620b606](https://github.com/ERC725Alliance/erc725.js/commit/620b60632e50ca59abedae9935f8b75d188278e0))
+- Remove .only call for testing. ([d5ef3c9](https://github.com/ERC725Alliance/erc725.js/commit/d5ef3c9965e2c5ad343f88a9c30a6281e9fa169b))
+- Remove console debugging. ([e349d57](https://github.com/ERC725Alliance/erc725.js/commit/e349d5715c7779c1eeb8d6e08c3ae3bf17eedd9e))
+- Remove unnecessary special case for 0x00000000 ([cd6152a](https://github.com/ERC725Alliance/erc725.js/commit/cd6152a88ca7a1c98184799b6fdc6982ff8a1cd6))
+- Repair and enhance test scripts ([224eb9e](https://github.com/ERC725Alliance/erc725.js/commit/224eb9ecb1b16f373f2ad17ee9d3efab08dda53b))
+- Repair as per PR review ([0a52452](https://github.com/ERC725Alliance/erc725.js/commit/0a5245230455324e9911e4e14992c50e6f645ba2))
+- Repair console.log and expand types of URLs (ar://, ipfs://, https\?://, data:) ([5c8f228](https://github.com/ERC725Alliance/erc725.js/commit/5c8f2285d2d23c59ef9707a54e419b55d25e4136))
+- Repair problems with IPFS, fetch and VerifiableURI ([44834b8](https://github.com/ERC725Alliance/erc725.js/commit/44834b8ed517e869ad99920b2853e30213a8d7b5))
+- Repair to not throw errors when data is not authentica or not accessible withing getDataFromExternalSources. ([25756d0](https://github.com/ERC725Alliance/erc725.js/commit/25756d09cecfec5d13d6e4fb6ed842c4e3d77734))
+- Repair tuples containing numeric types uintX/intX, add Number to output data type. ([01cceea](https://github.com/ERC725Alliance/erc725.js/commit/01cceeac03f719df6eb8be8c238aca4483e7a3e8))
+- Simplify buffer to string conversion. ([0bd1349](https://github.com/ERC725Alliance/erc725.js/commit/0bd1349f863283cf16cc6808bef48990ec118361))
+- Simplify creation of key to detect JSON. ([df2580d](https://github.com/ERC725Alliance/erc725.js/commit/df2580d9434dc386480f7eec2cd6e94a5b4ca7c1))
+- Use a single keccak function since ethereumjs converts it to a Buffer no matter what. ([cdc6c0a](https://github.com/ERC725Alliance/erc725.js/commit/cdc6c0a0f749209352d620db6d60865a276e072c))
 
 ## [0.22.0](https://github.com/ERC725Alliance/erc725.js/compare/v0.21.3...v0.22.0) (2023-12-15)
 
-
 ### ⚠ BREAKING CHANGES
 
-* update new LSP7/8 interface IDs ([#367](https://github.com/ERC725Alliance/erc725.js/issues/367))
-* `JSONURL` and `AssetURL` are now deprecated and have been replaced by `VerifiableURI`. The decoding is backward compatible but if you try to encode `JSONURL` and `AssetURL` value, they will be encoded as [`VerifiableURI`](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#verifiableuri). ([9aa87e5](https://github.com/ERC725Alliance/erc725.js/commit/9aa87e5ccc0fb1caac1f3291387370b3a980324b))
+- update new LSP7/8 interface IDs ([#367](https://github.com/ERC725Alliance/erc725.js/issues/367))
+- `JSONURL` and `AssetURL` are now deprecated and have been replaced by `VerifiableURI`. The decoding is backward compatible but if you try to encode `JSONURL` and `AssetURL` value, they will be encoded as [`VerifiableURI`](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#verifiableuri). ([9aa87e5](https://github.com/ERC725Alliance/erc725.js/commit/9aa87e5ccc0fb1caac1f3291387370b3a980324b))
 
 ### Bug Fixes
 
-* Rename JSONURLDataToEncode ([808f1b3](https://github.com/ERC725Alliance/erc725.js/commit/808f1b362bd2275424cf93ac6333049cde90216e))
+- Rename JSONURLDataToEncode ([808f1b3](https://github.com/ERC725Alliance/erc725.js/commit/808f1b362bd2275424cf93ac6333049cde90216e))
 
 ## [0.21.3](https://github.com/ERC725Alliance/erc725.js/compare/v0.21.2...v0.21.3) (2023-11-29)
 
-
 ### Features
 
-* add `encode/decodeValueType` as public callable methods ([#325](https://github.com/ERC725Alliance/erc725.js/issues/325)) ([a6fe7c8](https://github.com/ERC725Alliance/erc725.js/commit/a6fe7c8470688f573426b59fc2023a08da0cbd36))
-* add more schemas available to parse via `getSchema` ([#351](https://github.com/ERC725Alliance/erc725.js/issues/351)) ([b882379](https://github.com/ERC725Alliance/erc725.js/commit/b8823796c5f99d89d56954c894dfb6964adc552a))
-* add support for multi types in mappings ([#357](https://github.com/ERC725Alliance/erc725.js/issues/357)) ([ba92903](https://github.com/ERC725Alliance/erc725.js/commit/ba9290326efad0aab3855ad3f0ed2722180980ed))
-* add support to encode / decode any `uint8` to `uint256` types ([#355](https://github.com/ERC725Alliance/erc725.js/issues/355)) ([417a4e8](https://github.com/ERC725Alliance/erc725.js/commit/417a4e8ff2c74f3f9e35d0018a4973c97c6ac997))
-* allow to encode LSP2 Array length only ([#326](https://github.com/ERC725Alliance/erc725.js/issues/326)) ([3a6be55](https://github.com/ERC725Alliance/erc725.js/commit/3a6be551d889904b7d95e2630ab637f2a31feb50))
-
+- add `encode/decodeValueType` as public callable methods ([#325](https://github.com/ERC725Alliance/erc725.js/issues/325)) ([a6fe7c8](https://github.com/ERC725Alliance/erc725.js/commit/a6fe7c8470688f573426b59fc2023a08da0cbd36))
+- add more schemas available to parse via `getSchema` ([#351](https://github.com/ERC725Alliance/erc725.js/issues/351)) ([b882379](https://github.com/ERC725Alliance/erc725.js/commit/b8823796c5f99d89d56954c894dfb6964adc552a))
+- add support for multi types in mappings ([#357](https://github.com/ERC725Alliance/erc725.js/issues/357)) ([ba92903](https://github.com/ERC725Alliance/erc725.js/commit/ba9290326efad0aab3855ad3f0ed2722180980ed))
+- add support to encode / decode any `uint8` to `uint256` types ([#355](https://github.com/ERC725Alliance/erc725.js/issues/355)) ([417a4e8](https://github.com/ERC725Alliance/erc725.js/commit/417a4e8ff2c74f3f9e35d0018a4973c97c6ac997))
+- allow to encode LSP2 Array length only ([#326](https://github.com/ERC725Alliance/erc725.js/issues/326)) ([3a6be55](https://github.com/ERC725Alliance/erc725.js/commit/3a6be551d889904b7d95e2630ab637f2a31feb50))
 
 ### Bug Fixes
 
-* update lsp6 schema ([75c4044](https://github.com/ERC725Alliance/erc725.js/commit/75c40444e407d93076cc1e49ad706cc0055f383b))
+- update lsp6 schema ([75c4044](https://github.com/ERC725Alliance/erc725.js/commit/75c40444e407d93076cc1e49ad706cc0055f383b))
 
 ## [0.21.2](https://github.com/ERC725Alliance/erc725.js/compare/v0.21.1...v0.21.2) (2023-11-07)
 
-
 ### Bug Fixes
 
-* Add for unknown verification method to allow for null verification data in LSP2 ([f205818](https://github.com/ERC725Alliance/erc725.js/commit/f205818af348471bde8f88af2008497b8c13e258))
-* Add more fixes per PR comments ([e7302e4](https://github.com/ERC725Alliance/erc725.js/commit/e7302e4504408e2f4f6304badd2024bfe05fcf47))
-* Change to verification object ([ddd2ab2](https://github.com/ERC725Alliance/erc725.js/commit/ddd2ab23d1c5181745827f338d9abaea48c772f7))
-* More renames _FUNCTIONS to _METHODS ([1a96be1](https://github.com/ERC725Alliance/erc725.js/commit/1a96be1dd15942d2a844bc26b9ab73e053e3b766))
-* Move @types/jest and jest ([852918c](https://github.com/ERC725Alliance/erc725.js/commit/852918c72228b3839ba60730dadef66837008f5a))
+- Add for unknown verification method to allow for null verification data in LSP2 ([f205818](https://github.com/ERC725Alliance/erc725.js/commit/f205818af348471bde8f88af2008497b8c13e258))
+- Add more fixes per PR comments ([e7302e4](https://github.com/ERC725Alliance/erc725.js/commit/e7302e4504408e2f4f6304badd2024bfe05fcf47))
+- Change to verification object ([ddd2ab2](https://github.com/ERC725Alliance/erc725.js/commit/ddd2ab23d1c5181745827f338d9abaea48c772f7))
+- More renames \_FUNCTIONS to \_METHODS ([1a96be1](https://github.com/ERC725Alliance/erc725.js/commit/1a96be1dd15942d2a844bc26b9ab73e053e3b766))
+- Move @types/jest and jest ([852918c](https://github.com/ERC725Alliance/erc725.js/commit/852918c72228b3839ba60730dadef66837008f5a))
 
 ## [0.21.1](https://github.com/ERC725Alliance/erc725.js/compare/v0.21.0...v0.21.1) (2023-11-06)
 
-
 ### Bug Fixes
 
-* incorrect hex for `LSP8MetadataTokenURI` ([0500a75](https://github.com/ERC725Alliance/erc725.js/commit/0500a752e3117c5c7e9df8cfed22cb5d6fee20c5))
+- incorrect hex for `LSP8MetadataTokenURI` ([0500a75](https://github.com/ERC725Alliance/erc725.js/commit/0500a752e3117c5c7e9df8cfed22cb5d6fee20c5))
 
 ## [0.21.0](https://github.com/ERC725Alliance/erc725.js/compare/v0.20.1...v0.21.0) (2023-11-02)
 
-
 ### ⚠ BREAKING CHANGES
 
-* update lsp3/lsp4 verificationData
+- update lsp3/lsp4 verificationData
 
 ### Features
 
-* new gas parameter ([82e3833](https://github.com/ERC725Alliance/erc725.js/commit/82e383345a712619b5c6a1030b124d2625115fc1))
-
+- new gas parameter ([82e3833](https://github.com/ERC725Alliance/erc725.js/commit/82e383345a712619b5c6a1030b124d2625115fc1))
 
 ### Code Refactoring
 
-* update lsp3/lsp4 verificationData ([9640d9f](https://github.com/ERC725Alliance/erc725.js/commit/9640d9fbf88c7cf694b9e82cc3a711350334b097))
+- update lsp3/lsp4 verificationData ([9640d9f](https://github.com/ERC725Alliance/erc725.js/commit/9640d9fbf88c7cf694b9e82cc3a711350334b097))
 
 ## [0.20.1](https://github.com/ERC725Alliance/erc725.js/compare/v0.20.0...v0.20.1) (2023-10-30)
 
-
 ### Bug Fixes
 
-* incorrect permission value for `EXECUTE_RELAY_CALL` ([55b8f5e](https://github.com/ERC725Alliance/erc725.js/commit/55b8f5e64c29c5a85d872f605667c88c1546f6b3))
+- incorrect permission value for `EXECUTE_RELAY_CALL` ([55b8f5e](https://github.com/ERC725Alliance/erc725.js/commit/55b8f5e64c29c5a85d872f605667c88c1546f6b3))
 
 ## [0.20.0](https://github.com/ERC725Alliance/erc725.js/compare/v0.19.0...v0.20.0) (2023-10-18)
 
-
 ### Features
 
-* add permission `EXECUTE_RELAY_CALL` ([6db8835](https://github.com/ERC725Alliance/erc725.js/commit/6db8835ccd9d1082d9e8184bb2f14972760bea69))
+- add permission `EXECUTE_RELAY_CALL` ([6db8835](https://github.com/ERC725Alliance/erc725.js/commit/6db8835ccd9d1082d9e8184bb2f14972760bea69))
 
 ## [0.19.0](https://github.com/ERC725Alliance/erc725.js/compare/v0.18.0...v0.19.0) (2023-10-05)
 
-
 ### ⚠ BREAKING CHANGES
 
-* change LSP3 to SupportedStandards:LSP3Profile ([#307](https://github.com/ERC725Alliance/erc725.js/issues/307))
-* new encoding for static value types (not arrays `[]`) ([#288](https://github.com/ERC725Alliance/erc725.js/issues/288))
-* change `ArrayLength` value from `uint256` to `uint128` ([#287](https://github.com/ERC725Alliance/erc725.js/issues/287))
+- change LSP3 to SupportedStandards:LSP3Profile ([#307](https://github.com/ERC725Alliance/erc725.js/issues/307))
+- new encoding for static value types (not arrays `[]`) ([#288](https://github.com/ERC725Alliance/erc725.js/issues/288))
+- change `ArrayLength` value from `uint256` to `uint128` ([#287](https://github.com/ERC725Alliance/erc725.js/issues/287))
 
 ### Features
 
-* add checkPermissions function ([17d2258](https://github.com/ERC725Alliance/erc725.js/commit/17d225843c236951ef1515a0ff91095b5ef27cd3))
-* add schemas for LSP8 + LSP17 ([#311](https://github.com/ERC725Alliance/erc725.js/issues/311)) ([1e8dbf7](https://github.com/ERC725Alliance/erc725.js/commit/1e8dbf765c6c5e250539b402e9bd5a395966a8c2))
-
+- add checkPermissions function ([17d2258](https://github.com/ERC725Alliance/erc725.js/commit/17d225843c236951ef1515a0ff91095b5ef27cd3))
+- add schemas for LSP8 + LSP17 ([#311](https://github.com/ERC725Alliance/erc725.js/issues/311)) ([1e8dbf7](https://github.com/ERC725Alliance/erc725.js/commit/1e8dbf765c6c5e250539b402e9bd5a395966a8c2))
 
 ### Bug Fixes
 
-* decode any uint256 as number not string ([#289](https://github.com/ERC725Alliance/erc725.js/issues/289)) ([37203f1](https://github.com/ERC725Alliance/erc725.js/commit/37203f14d313a0caff75724dc74175c741c1b540))
-* dependencies & example ([#302](https://github.com/ERC725Alliance/erc725.js/issues/302)) ([9979e89](https://github.com/ERC725Alliance/erc725.js/commit/9979e89e438cd9f7cc586d7dc271de969f13b125))
-* incorrect value in schema for array length in `...Map` ([#310](https://github.com/ERC725Alliance/erc725.js/issues/310)) ([0d28b13](https://github.com/ERC725Alliance/erc725.js/commit/0d28b1317dc085078090a8babacf4db517d91a87))
-* Remove hardcoded require ([5279278](https://github.com/ERC725Alliance/erc725.js/commit/527927812b1a05b13f8dc6b14aecaa6d24e98d61))
-* variable naming ([44b4785](https://github.com/ERC725Alliance/erc725.js/commit/44b47851ed63b817edc21c63655d67bac13a7e7f))
-
+- decode any uint256 as number not string ([#289](https://github.com/ERC725Alliance/erc725.js/issues/289)) ([37203f1](https://github.com/ERC725Alliance/erc725.js/commit/37203f14d313a0caff75724dc74175c741c1b540))
+- dependencies & example ([#302](https://github.com/ERC725Alliance/erc725.js/issues/302)) ([9979e89](https://github.com/ERC725Alliance/erc725.js/commit/9979e89e438cd9f7cc586d7dc271de969f13b125))
+- incorrect value in schema for array length in `...Map` ([#310](https://github.com/ERC725Alliance/erc725.js/issues/310)) ([0d28b13](https://github.com/ERC725Alliance/erc725.js/commit/0d28b1317dc085078090a8babacf4db517d91a87))
+- Remove hardcoded require ([5279278](https://github.com/ERC725Alliance/erc725.js/commit/527927812b1a05b13f8dc6b14aecaa6d24e98d61))
+- variable naming ([44b4785](https://github.com/ERC725Alliance/erc725.js/commit/44b47851ed63b817edc21c63655d67bac13a7e7f))
 
 ### Code Refactoring
 
-* change `ArrayLength` value from `uint256` to `uint128` ([#287](https://github.com/ERC725Alliance/erc725.js/issues/287)) ([c95ee8a](https://github.com/ERC725Alliance/erc725.js/commit/c95ee8a53bf25bcf47777054af27cae1fbad8b2f))
-* change LSP3 to SupportedStandards:LSP3Profile ([#307](https://github.com/ERC725Alliance/erc725.js/issues/307)) ([73f3481](https://github.com/ERC725Alliance/erc725.js/commit/73f34818fe152c3ab5299177adc0eddfed6886c5))
-* new encoding for static value types (not arrays `[]`) ([#288](https://github.com/ERC725Alliance/erc725.js/issues/288)) ([f0b04da](https://github.com/ERC725Alliance/erc725.js/commit/f0b04daa57a281c537a8f28594439573188f0dce))
+- change `ArrayLength` value from `uint256` to `uint128` ([#287](https://github.com/ERC725Alliance/erc725.js/issues/287)) ([c95ee8a](https://github.com/ERC725Alliance/erc725.js/commit/c95ee8a53bf25bcf47777054af27cae1fbad8b2f))
+- change LSP3 to SupportedStandards:LSP3Profile ([#307](https://github.com/ERC725Alliance/erc725.js/issues/307)) ([73f3481](https://github.com/ERC725Alliance/erc725.js/commit/73f34818fe152c3ab5299177adc0eddfed6886c5))
+- new encoding for static value types (not arrays `[]`) ([#288](https://github.com/ERC725Alliance/erc725.js/issues/288)) ([f0b04da](https://github.com/ERC725Alliance/erc725.js/commit/f0b04daa57a281c537a8f28594439573188f0dce))
 
 ## [0.18.0](https://github.com/ERC725Alliance/erc725.js/compare/v0.17.2...v0.18.0) (2023-08-03)
 

--- a/biome.json
+++ b/biome.json
@@ -7,8 +7,29 @@
         "noExplicitAny": "off"
       },
       "style": {
-        "useImportType": "off"
+        "useImportType": "off",
+        "useNodejsImportProtocol": "off"
+      },
+      "complexity": {
+        "noForEach": "off"
       }
     }
+  },
+  "formatter": {
+    "indentWidth": 2,
+    "indentStyle": "space"
+  },
+  "javascript": {
+    "formatter": {
+      "semicolons": "always",
+      "quoteStyle": "single",
+      "trailingComma": "all"
+    }
+  },
+  "organizeImports": {
+    "enabled": false
+  },
+  "files": {
+    "ignore": ["node_modules", "build", "coverage", ".vscode"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "web3-utils": "^1.10.0"
       },
       "devDependencies": {
+        "@biomejs/biome": "^1.6.4",
         "@types/chai": "^4.3.4",
         "@types/isomorphic-fetch": "^0.0.36",
         "@types/jest": "^27.5.2",
@@ -707,6 +708,161 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.6.4.tgz",
+      "integrity": "sha512-3groVd2oWsLC0ZU+XXgHSNbq31lUcOCBkCcA7sAQGBopHcmL+jmmdoWlY3S61zIh+f2mqQTQte1g6PZKb3JJjA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "1.6.4",
+        "@biomejs/cli-darwin-x64": "1.6.4",
+        "@biomejs/cli-linux-arm64": "1.6.4",
+        "@biomejs/cli-linux-arm64-musl": "1.6.4",
+        "@biomejs/cli-linux-x64": "1.6.4",
+        "@biomejs/cli-linux-x64-musl": "1.6.4",
+        "@biomejs/cli-win32-arm64": "1.6.4",
+        "@biomejs/cli-win32-x64": "1.6.4"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.6.4.tgz",
+      "integrity": "sha512-2WZef8byI9NRzGajGj5RTrroW9BxtfbP9etigW1QGAtwu/6+cLkdPOWRAs7uFtaxBNiKFYA8j/BxV5zeAo5QOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.6.4.tgz",
+      "integrity": "sha512-uo1zgM7jvzcoDpF6dbGizejDLCqNpUIRkCj/oEK0PB0NUw8re/cn1EnxuOLZqDpn+8G75COLQTOx8UQIBBN/Kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.6.4.tgz",
+      "integrity": "sha512-wAOieaMNIpLrxGc2/xNvM//CIZg7ueWy3V5A4T7gDZ3OL/Go27EKE59a+vMKsBCYmTt7jFl4yHz0TUkUbodA/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.6.4.tgz",
+      "integrity": "sha512-Hp8Jwt6rjj0wCcYAEN6/cfwrrPLLlGOXZ56Lei4Pt4jy39+UuPeAVFPeclrrCfxyL1wQ2xPrhd/saTHSL6DoJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.6.4.tgz",
+      "integrity": "sha512-qTWhuIw+/ePvOkjE9Zxf5OqSCYxtAvcTJtVmZT8YQnmY2I62JKNV2m7tf6O5ViKZUOP0mOQ6NgqHKcHH1eT8jw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.6.4.tgz",
+      "integrity": "sha512-wqi0hr8KAx5kBO0B+m5u8QqiYFFBJOSJVSuRqTeGWW+GYLVUtXNidykNqf1JsW6jJDpbkSp2xHKE/bTlVaG2Kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.6.4.tgz",
+      "integrity": "sha512-Wp3FiEeF6v6C5qMfLkHwf4YsoNHr/n0efvoC8jCKO/kX05OXaVExj+1uVQ1eGT7Pvx0XVm/TLprRO0vq/V6UzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.6.4.tgz",
+      "integrity": "sha512-mz183Di5hTSGP7KjNWEhivcP1wnHLGmOxEROvoFsIxMYtDhzJDad4k5gI/1JbmA0xe4n52vsgqo09tBhrMT/Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -13868,6 +14024,78 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@biomejs/biome": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.6.4.tgz",
+      "integrity": "sha512-3groVd2oWsLC0ZU+XXgHSNbq31lUcOCBkCcA7sAQGBopHcmL+jmmdoWlY3S61zIh+f2mqQTQte1g6PZKb3JJjA==",
+      "dev": true,
+      "requires": {
+        "@biomejs/cli-darwin-arm64": "1.6.4",
+        "@biomejs/cli-darwin-x64": "1.6.4",
+        "@biomejs/cli-linux-arm64": "1.6.4",
+        "@biomejs/cli-linux-arm64-musl": "1.6.4",
+        "@biomejs/cli-linux-x64": "1.6.4",
+        "@biomejs/cli-linux-x64-musl": "1.6.4",
+        "@biomejs/cli-win32-arm64": "1.6.4",
+        "@biomejs/cli-win32-x64": "1.6.4"
+      }
+    },
+    "@biomejs/cli-darwin-arm64": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.6.4.tgz",
+      "integrity": "sha512-2WZef8byI9NRzGajGj5RTrroW9BxtfbP9etigW1QGAtwu/6+cLkdPOWRAs7uFtaxBNiKFYA8j/BxV5zeAo5QOQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-darwin-x64": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.6.4.tgz",
+      "integrity": "sha512-uo1zgM7jvzcoDpF6dbGizejDLCqNpUIRkCj/oEK0PB0NUw8re/cn1EnxuOLZqDpn+8G75COLQTOx8UQIBBN/Kg==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-arm64": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.6.4.tgz",
+      "integrity": "sha512-wAOieaMNIpLrxGc2/xNvM//CIZg7ueWy3V5A4T7gDZ3OL/Go27EKE59a+vMKsBCYmTt7jFl4yHz0TUkUbodA/w==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-arm64-musl": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.6.4.tgz",
+      "integrity": "sha512-Hp8Jwt6rjj0wCcYAEN6/cfwrrPLLlGOXZ56Lei4Pt4jy39+UuPeAVFPeclrrCfxyL1wQ2xPrhd/saTHSL6DoJg==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-x64": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.6.4.tgz",
+      "integrity": "sha512-qTWhuIw+/ePvOkjE9Zxf5OqSCYxtAvcTJtVmZT8YQnmY2I62JKNV2m7tf6O5ViKZUOP0mOQ6NgqHKcHH1eT8jw==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-x64-musl": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.6.4.tgz",
+      "integrity": "sha512-wqi0hr8KAx5kBO0B+m5u8QqiYFFBJOSJVSuRqTeGWW+GYLVUtXNidykNqf1JsW6jJDpbkSp2xHKE/bTlVaG2Kg==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-win32-arm64": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.6.4.tgz",
+      "integrity": "sha512-Wp3FiEeF6v6C5qMfLkHwf4YsoNHr/n0efvoC8jCKO/kX05OXaVExj+1uVQ1eGT7Pvx0XVm/TLprRO0vq/V6UzA==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-win32-x64": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.6.4.tgz",
+      "integrity": "sha512-mz183Di5hTSGP7KjNWEhivcP1wnHLGmOxEROvoFsIxMYtDhzJDad4k5gI/1JbmA0xe4n52vsgqo09tBhrMT/Zg==",
+      "dev": true,
+      "optional": true
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@erc725/erc725.js",
-  "version": "0.24.0",
+  "version": "0.24.1-dev.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@erc725/erc725.js",
-      "version": "0.24.0",
+      "version": "0.24.1-dev.5",
       "license": "Apache-2.0",
       "dependencies": {
         "add": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erc725/erc725.js",
-  "version": "0.24.0",
+  "version": "0.24.1-dev.5",
   "description": "Library to interact with ERC725 smart contracts",
   "main": "build/main/src/index.js",
   "typings": "build/main/src/index.d.ts",
@@ -16,6 +16,8 @@
     "build:module": "tsc -p tsconfig.module.json",
     "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' nyc --reporter=text --reporter=lcov mocha",
     "lint": "eslint . --ext .ts",
+    "format:fix": "prettier --write .",
+    "format": "prettier .",
     "release": "standard-version"
   },
   "repository": {
@@ -51,6 +53,7 @@
   },
   "homepage": "https://github.com/ERC725Alliance/erc725.js#readme",
   "devDependencies": {
+    "@biomejs/biome": "^1.6.4",
     "@types/chai": "^4.3.4",
     "@types/isomorphic-fetch": "^0.0.36",
     "@types/jest": "^27.5.2",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1548,7 +1548,7 @@ describe('Running @erc725/erc725.js tests...', () => {
         assert.strictEqual(
           redecodedPermissions.CALL,
           false,
-          'Re-reencoded permissions includes CALL',
+          'Re-reencoded permissions does not include CALL',
         );
       });
 
@@ -1567,6 +1567,13 @@ describe('Running @erc725/erc725.js tests...', () => {
           true,
           'Re-reencoded permissions includes SUPER_DELEGATECALL',
         );
+
+        assert.strictEqual(
+          redecodedPermissions.ALL_PERMISSIONS,
+          true,
+          'Re-reencoded permissions includes ALL_PERMISSIONS',
+        );
+
         assert.strictEqual(
           redecodedPermissions.DELEGATECALL,
           true,

--- a/src/lib/detector.test.ts
+++ b/src/lib/detector.test.ts
@@ -24,7 +24,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { INTERFACE_IDS_0_12_0 } from '../constants/interfaces';
 
-import { supportsInterface, checkPermissions } from './detector';
+import { internalSupportsInterface, checkPermissions } from './detector';
 
 describe('supportsInterface', () => {
   it('it should return true if the contract supports the interface with name', async () => {
@@ -37,10 +37,13 @@ describe('supportsInterface', () => {
       .withArgs(contractAddress, INTERFACE_IDS_0_12_0[interfaceName])
       .returns(Promise.resolve(true));
 
-    const doesSupportInterface = await supportsInterface(interfaceName, {
-      address: contractAddress,
-      provider: providerStub,
-    });
+    const doesSupportInterface = await internalSupportsInterface(
+      interfaceName,
+      {
+        address: contractAddress,
+        provider: providerStub,
+      },
+    );
 
     expect(doesSupportInterface).to.be.true;
   });
@@ -55,7 +58,7 @@ describe('supportsInterface', () => {
       .withArgs(contractAddress, interfaceId)
       .returns(Promise.resolve(true));
 
-    const doesSupportInterface = await supportsInterface(interfaceId, {
+    const doesSupportInterface = await internalSupportsInterface(interfaceId, {
       address: contractAddress,
       provider: providerStub,
     });

--- a/src/lib/detector.ts
+++ b/src/lib/detector.ts
@@ -36,7 +36,7 @@ import {
  * @param options Object with address and RPC URL.
  * @returns {Promise<boolean>} if interface is supported.
  */
-export const supportsInterface = async (
+export const internalSupportsInterface = async (
   interfaceIdOrName: string,
   options: AddressProviderOptions,
 ): Promise<boolean> => {

--- a/src/lib/encoder.test.ts
+++ b/src/lib/encoder.test.ts
@@ -250,9 +250,8 @@ describe('encoder', () => {
           // over the max uint256 allowed, does not fit in 32 bytes
           input: toHex(
             toBN(
-              '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff' +
-                1,
-            ),
+              '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+            ).add(toBN(1)),
           ),
         },
       ];

--- a/src/lib/getDataFromExternalSources.ts
+++ b/src/lib/getDataFromExternalSources.ts
@@ -80,7 +80,7 @@ export const getDataFromExternalSources = (
         ipfsGateway,
       );
       try {
-        if (/[=?/]$/.test(url)) {
+        if (!url.startsWith('data:') && /[=?/]$/.test(url)) {
           // this URL is not verifiable and the URL ends with a / or ? or = meaning it's not a file
           // and more likely to be some kind of directory or query BaseURI
           return dataEntry;

--- a/src/types/Method.ts
+++ b/src/types/Method.ts
@@ -49,4 +49,5 @@ export interface Permissions {
   EXECUTE_RELAY_CALL?: boolean;
   ERC4337_PERMISSION?: boolean;
   ALL_PERMISSIONS?: boolean;
+  [key: string]: boolean | undefined;
 }

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -1,4 +1,4 @@
-export const enum ProviderTypes {
+export enum ProviderTypes {
   ETHEREUM = 'ETHEREUM',
   WEB3 = 'WEB3',
 }


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

Filter out keys from LSP6_DEFAULT_PERMISSIONS because it now has ALL_PERMISSIONS.
Having ALL_PERMISSIONS set during encodePermissions will always return ALL_PERMISSIONS.
Currently calling decodePermissions will always return ALL_PERMISSIONS on.

### What is the current behaviour (you can also link to an open issue here)?

### What is the new behaviour (if this is a feature change)?

### Other information:
