### PR TITLE
feat: export methods for encoding/decoding dataSourceWithHash and valueContent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,10 +58,19 @@ import { decodeData } from './lib/decodeData';
 import { getDataFromExternalSources } from './lib/getDataFromExternalSources';
 import { DynamicKeyPart, DynamicKeyParts } from './types/dynamicKeys';
 import { getData } from './lib/getData';
-import { decodeValueType, encodeValueType } from './lib/encoder';
+import {
+  encodeDataSourceWithHash,
+  decodeDataSourceWithHash,
+  encodeValueType,
+  decodeValueType,
+  encodeValueContent,
+  decodeValueContent,
+} from './lib/encoder';
 import { internalSupportsInterface, checkPermissions } from './lib/detector';
 import { decodeMappingKey } from './lib/decodeMappingKey';
 import { encodePermissions, decodePermissions } from './lib/permissions';
+import { AssetURLEncode } from './types/encodeData';
+import { URLDataToEncode, URLDataWithHash, Verification } from './types';
 
 export {
   ERC725JSONSchema,
@@ -77,9 +86,12 @@ export { decodeData } from './lib/decodeData';
 export { encodeKeyName, isDynamicKeyName } from './lib/encodeKeyName';
 export { decodeMappingKey } from './lib/decodeMappingKey';
 export {
-  decodeValueType,
-  decodeValueContent,
+  encodeDataSourceWithHash,
+  decodeDataSourceWithHash,
   encodeValueType,
+  decodeValueType,
+  encodeValueContent,
+  decodeValueContent,
 } from './lib/encoder';
 export { getDataFromExternalSources } from './lib/getDataFromExternalSources';
 export { encodePermissions, decodePermissions } from './lib/permissions';
@@ -646,6 +658,28 @@ export class ERC725 {
     return checkPermissions(requiredPermissions, grantedPermissions);
   }
 
+  encodeDataSourceWithHash(
+    verification: undefined | Verification,
+    dataSource: string,
+  ): string {
+    return encodeDataSourceWithHash(verification, dataSource);
+  }
+
+  static encodeDataSourceWithHash(
+    verification: undefined | Verification,
+    dataSource: string,
+  ): string {
+    return encodeDataSourceWithHash(verification, dataSource);
+  }
+
+  decodeDataSourceWithHash(value: string): URLDataWithHash {
+    return decodeDataSourceWithHash(value);
+  }
+
+  static decodeDataSourceWithHash(value: string): URLDataWithHash {
+    return decodeDataSourceWithHash(value);
+  }
+
   /**
    * @param type The valueType to encode the value as
    * @param value The value to encode
@@ -676,6 +710,34 @@ export class ERC725 {
 
   decodeValueType(type: string, data: string) {
     return decodeValueType(type, data);
+  }
+
+  static encodeValueContent(
+    valueContent: string,
+    value: string | number | AssetURLEncode | URLDataToEncode | boolean,
+  ): string | false {
+    return encodeValueContent(valueContent, value);
+  }
+
+  encodeValueContent(
+    valueContent: string,
+    value: string | number | AssetURLEncode | URLDataToEncode | boolean,
+  ): string | false {
+    return encodeValueContent(valueContent, value);
+  }
+
+  static decodeValueContent(
+    valueContent: string,
+    value: string,
+  ): string | URLDataWithHash | number | boolean | null {
+    return decodeValueContent(valueContent, value);
+  }
+
+  decodeValueContent(
+    valueContent: string,
+    value: string,
+  ): string | URLDataWithHash | number | boolean | null {
+    return decodeValueContent(valueContent, value);
   }
 }
 

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -68,7 +68,7 @@ const BytesNValueContentRegex = /Bytes(\d+)/;
 
 const ALLOWED_BYTES_SIZES = [2, 4, 8, 16, 32, 64, 128, 256];
 
-const encodeDataSourceWithHash = (
+export const encodeDataSourceWithHash = (
   verification: undefined | Verification,
   dataSource: string,
 ): string => {
@@ -94,7 +94,7 @@ const encodeDataSourceWithHash = (
   ].join('');
 };
 
-const decodeDataSourceWithHash = (value: string): URLDataWithHash => {
+export const decodeDataSourceWithHash = (value: string): URLDataWithHash => {
   if (value.slice(0, 6) === '0x0000') {
     // DEAL with VerifiableURI
     // NOTE: A JSONURL with a 0x00000000 verification method is invalid.


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

:star:
### What is the current behaviour (you can also link to an open issue here)?

Currently, there are no methods available in the ERC725 class for:
- encoding / decoding value Content
- encoding / decoding JSONURL or VerifiableURI

This is useful for tools like ERC725-inspect, lsp-utils, or services like indexers to easily decode data from logs / fetched from contracts, or prepare data easily without requiring a full schema.

### What is the new behaviour (if this is a feature change)?

Add the following methods:
- `encodeDataSourceWithHash(...)`
- `decodeDataSourceWithHash(...)`
- `encodeValueContent(...)`
- `decodeValueContent(...)`

 available to be imported individually like this:

```js
import { encodeDataSourceWithHash } from "@erc725/erc725.js"
```

or from the ERC725 class (as static methods or accessible in an instance).

### Other information:
