### PR TITLE
fix: Ignore package.json formatting in biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -30,6 +30,13 @@
     "enabled": false
   },
   "files": {
-    "ignore": ["node_modules", ".nyc_output", "build", "coverage", ".vscode"]
+    "ignore": [
+      "node_modules",
+      ".nyc_output",
+      "build",
+      "coverage",
+      ".vscode",
+      "package.json"
+    ]
   }
 }


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

Biome will find different formatting in package.json due to the release-please
update and the merge to main and then release chore will fail.

### What is the current behaviour (you can also link to an open issue here)?

Ignore formatting inside of package.json

### What is the new behaviour (if this is a feature change)?

### Other information:
