### PR TITLE
feat: add support for encoding `bytes1` to `bytes32` + fix incorrect encoding `uintN`

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -889,6 +889,60 @@ describe('Running @erc725/erc725.js tests...', () => {
     });
   });
 
+  describe('Testing `encodeData`', () => {
+    describe('for `uintN` as `Number`', () => {
+      [
+        { valueType: 'uint8', valueToEncode: 10, expectedEncodedValue: '0x0a' },
+        {
+          valueType: 'uint16',
+          valueToEncode: 10,
+          expectedEncodedValue: '0x000a',
+        },
+        {
+          valueType: 'uint24',
+          valueToEncode: 10,
+          expectedEncodedValue: '0x00000a',
+        },
+        {
+          valueType: 'uint32',
+          valueToEncode: 10,
+          expectedEncodedValue: '0x0000000a',
+        },
+        {
+          valueType: 'uint128',
+          valueToEncode: 10,
+          expectedEncodedValue: '0x0000000000000000000000000000000a',
+        },
+        {
+          valueType: 'uint256',
+          valueToEncode: 10,
+          expectedEncodedValue:
+            '0x000000000000000000000000000000000000000000000000000000000000000a',
+        },
+      ].forEach((testCase) => {
+        it('should encode a valueType `uintN` as valueContent `Number` correctly with the right padding', () => {
+          const schema = {
+            name: 'ExampleUintN',
+            key: '0x512cddbe2654abd240fafbed308d91e82ff977301943f08ea825ba3e435bfa57',
+            keyType: 'Singleton',
+            valueType: testCase.valueType,
+            valueContent: 'Number',
+          };
+          const erc725js = new ERC725([schema]);
+          const result = erc725js.encodeData([
+            { keyName: schema.name, value: testCase.valueToEncode },
+          ]);
+
+          assert.equal(result.values[0], testCase.expectedEncodedValue);
+        });
+      });
+    });
+  });
+
+  describe('Testing `decodeData`', () => {
+    // ...
+  });
+
   describe('Testing utility encoding & decoding functions', () => {
     const allGraphData = generateAllData(mockSchema) as any;
     /* **************************************** */

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -939,10 +939,6 @@ describe('Running @erc725/erc725.js tests...', () => {
     });
   });
 
-  describe('Testing `decodeData`', () => {
-    // ...
-  });
-
   describe('Testing utility encoding & decoding functions', () => {
     const allGraphData = generateAllData(mockSchema) as any;
     /* **************************************** */

--- a/src/lib/encoder.test.ts
+++ b/src/lib/encoder.test.ts
@@ -145,16 +145,35 @@ describe('encoder', () => {
           encodedValue: '0x7765656b', // utf8-encoded characters
           decodedValue: '0x7765656b',
         },
-        {
-          valueType: 'bytes4',
-          input: 1122334455,
-          encodedValue: '0x42e576f7', // number converted to hex + right padded
-          decodedValue: '0x42e576f7',
-        },
       ];
 
       oneWayEncodingTestCases.forEach((testCase) => {
         it(`encodes one way \`input\` = ${testCase.input} as ${testCase.valueType}, but does not decode back as the same input`, async () => {
+          const encodedValue = encodeValueType(
+            testCase.valueType,
+            testCase.input,
+          );
+
+          assert.deepStrictEqual(encodedValue, testCase.encodedValue);
+          assert.deepStrictEqual(
+            decodeValueType(testCase.valueType, encodedValue),
+            testCase.decodedValue,
+          );
+        });
+      });
+
+      const leftPaddedTestCases = [
+        {
+          valueType: 'bytes4',
+          input: 1122334455,
+          encodedValue: '0x42e576f7', // number converted to hex + left padded still
+          decodedValue: '0x42e576f7',
+        },
+      ];
+
+      // numbers encoded as `bytesN` are left padded to allow symmetric encoding / decoding
+      leftPaddedTestCases.forEach((testCase) => {
+        it(`encodes + left pad numbers \`input\` = ${testCase.input} as ${testCase.valueType} padded on the left with \`00\`s`, async () => {
           const encodedValue = encodeValueType(
             testCase.valueType,
             testCase.input,
@@ -273,18 +292,36 @@ describe('encoder', () => {
           encodedValue:
             '0x546869732073656e74656e6365206973203332206279746573206c6f6e672021',
         },
-        {
-          valueType: 'bytes32',
-          input: 12345,
-          decodedValue:
-            '0x3039000000000000000000000000000000000000000000000000000000000000',
-          encodedValue:
-            '0x3039000000000000000000000000000000000000000000000000000000000000',
-        },
       ];
 
       oneWayEncodingTestCases.forEach((testCase) => {
         it(`encodes one way \`input\` = ${testCase.input} as ${testCase.valueType}, but does not decode back as the same input`, async () => {
+          const encodedValue = encodeValueType(
+            testCase.valueType,
+            testCase.input,
+          );
+
+          assert.deepStrictEqual(encodedValue, testCase.encodedValue);
+          assert.deepStrictEqual(
+            decodeValueType(testCase.valueType, encodedValue),
+            testCase.decodedValue,
+          );
+        });
+      });
+
+      const leftPaddedTestCases = [
+        {
+          valueType: 'bytes32',
+          input: 12345,
+          decodedValue:
+            '0x0000000000000000000000000000000000000000000000000000000000003039',
+          encodedValue:
+            '0x0000000000000000000000000000000000000000000000000000000000003039',
+        },
+      ];
+
+      leftPaddedTestCases.forEach((testCase) => {
+        it(`encodes + left pad \`input\` = ${testCase.input} as ${testCase.valueType} padded on the right with \`00\`s`, async () => {
           const encodedValue = encodeValueType(
             testCase.valueType,
             testCase.input,

--- a/src/lib/encoder.test.ts
+++ b/src/lib/encoder.test.ts
@@ -321,7 +321,7 @@ describe('encoder', () => {
       ];
 
       leftPaddedTestCases.forEach((testCase) => {
-        it(`encodes + left pad \`input\` = ${testCase.input} as ${testCase.valueType} padded on the right with \`00\`s`, async () => {
+        it(`encodes + left pad number \`input\` = ${testCase.input} as ${testCase.valueType} padded on the left with \`00\`s`, async () => {
           const encodedValue = encodeValueType(
             testCase.valueType,
             testCase.input,

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -65,9 +65,7 @@ import { ERC725JSONSchemaValueType } from '../types/ERC725JSONSchema';
 const abiCoder = AbiCoder;
 
 const uintNValueTypeRegex = /^uint(\d+)$/;
-``;
 const bytesNValueTypeRegex = /^bytes(\d+)$/;
-``;
 const BytesNValueContentRegex = /Bytes(\d+)/;
 
 export const encodeDataSourceWithHash = (
@@ -211,7 +209,7 @@ const encodeToBytesN = (
   bytesN: BytesNValueTypes,
   value: string | number,
 ): string => {
-  const numberOfBytesInType = parseInt(bytesN.split('bytes')[1], 10);
+  const numberOfBytesInType = Number.parseInt(bytesN.split('bytes')[1], 10);
 
   let valueToEncode: string;
 
@@ -985,7 +983,7 @@ export function decodeValueContent(
   value: string,
 ): string | URLDataWithHash | number | boolean | null {
   if (isValueContentLiteralHex(valueContent)) {
-    if (valueContent.toLowerCase() != value) {
+    if (valueContent.toLowerCase() !== value) {
       throw new Error(
         `Could not decode value content: the value ${value} does not match the Hex Literal ${valueContent} defined in the \`valueContent\` part of the schema`,
       );

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -57,7 +57,8 @@ import {
   countNumberOfBytes,
   isValidUintSize,
   countSignificantBits,
-  isValidBytesSize,
+  isValidByteSize,
+  isValueContentLiteralHex,
 } from './utils';
 import { ERC725JSONSchemaValueType } from '../types/ERC725JSONSchema';
 
@@ -602,7 +603,7 @@ const valueTypeEncodingMap = (
     case `bytes${bytesLength}`:
       return {
         encode: (value: string | number) => {
-          if (!isValidBytesSize(bytesLength as number)) {
+          if (!isValidByteSize(bytesLength as number)) {
             throw new Error(
               `Can't encode ${value} as ${type}. Invalid \`bytesN\` provided. Expected a \`N\` value for bytesN between 1 and 32.`,
             );
@@ -822,7 +823,7 @@ export const valueContentEncodingMap = (
             throw new Error(`Value: ${value} is not hex.`);
           }
 
-          if (bytesLength && !isValidBytesSize(bytesLength)) {
+          if (bytesLength && !isValidByteSize(bytesLength)) {
             throw new Error(
               `Provided bytes length: ${bytesLength} for encoding valueContent: ${valueContent} is not valid.`,
             );
@@ -844,7 +845,7 @@ export const valueContentEncodingMap = (
             return null;
           }
 
-          if (bytesLength && !isValidBytesSize(bytesLength)) {
+          if (bytesLength && !isValidByteSize(bytesLength)) {
             console.error(
               `Provided bytes length: ${bytesLength} for encoding valueContent: ${valueContent} is not valid.`,
             );
@@ -981,8 +982,13 @@ export function decodeValueContent(
   valueContent: string,
   value: string,
 ): string | URLDataWithHash | number | boolean | null {
-  if (valueContent.slice(0, 2) === '0x') {
-    return valueContent === value ? value : null;
+  if (isValueContentLiteralHex(valueContent)) {
+    if (valueContent.toLowerCase() != value) {
+      throw new Error(
+        `Could not decode value content: the value ${value} does not match the Hex Literal ${valueContent} defined in the \`valueContent\` part of the schema`,
+      );
+    }
+    return valueContent;
   }
 
   if (value == null || value === '0x') {

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -219,7 +219,9 @@ const encodeToBytesN = (
     // if we receive a plain string (e.g: "hey!"), convert it to utf8-hex data
     valueToEncode = toHex(value);
   } else if (typeof value === 'number') {
-    // if we receive a number as input, convert it to hex, left padded
+    // if we receive a number as input, convert it to hex,
+    // despite `bytesN` pads on the right, we pad number on the left side here
+    // to symmetrically encode / decode
     valueToEncode = padLeft(numberToHex(value), numberOfBytesInType * 2);
   } else {
     valueToEncode = value;

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -378,7 +378,7 @@ describe('utils', () => {
         valueContent: '0xc9aaAE3201F40fd0fF04D9c885769d8256A456ab',
         valueType: 'bytes',
         decodedValue: '0xc9aaAE3201F40fd0fF04D9c885769d8256A456ab',
-        encodedValue: '0xc9aaAE3201F40fd0fF04D9c885769d8256A456ab',
+        encodedValue: '0xc9aaae3201f40fd0ff04d9c885769d8256a456ab', // encoded hex is always lower case
       },
     ];
 

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -414,6 +414,12 @@ describe('utils', () => {
         encodedValue: '0xdeadbeaf0000000000000010',
         decodedValue: ['0xdeadbeaf', 16],
       },
+      {
+        valueContent: '(Bytes4,Number)',
+        valueType: '(bytes4,uint128)',
+        encodedValue: '0xdeadbeaf00000000000000000000000000000020',
+        decodedValue: ['0xdeadbeaf', 32],
+      },
     ]; // we may need to add more test cases! Address, etc.
 
     testCases.forEach((testCase) => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -23,6 +23,7 @@ import {
   checkAddressChecksum,
   hexToBytes,
   isAddress,
+  isHexStrict,
   leftPad,
   numberToHex,
   padLeft,
@@ -60,10 +61,6 @@ import { getSchemaElement } from './getSchemaElement';
 import { EncodeDataInput } from '../types/decodeData';
 import { GetDataDynamicKey } from '../types/GetData';
 import { isValidTuple } from './decodeData';
-
-function isValueContentLiteralHex(valueContent: string): boolean {
-  return valueContent.slice(0, 2) === '0x';
-}
 
 /**
  *
@@ -823,6 +820,15 @@ export function isValidUintSize(bitSize: number) {
  *
  * @param bytesSize the size of the fixed size bytes value
  */
-export function isValidBytesSize(bytesSize: number) {
+export function isValidByteSize(bytesSize: number) {
   return bytesSize >= 1 && bytesSize <= 32;
+}
+
+/**
+ * @dev Check if the `valueContent` in a schema is defined as an hex literal string
+ * @param valueContent The valueContent part of a schema
+ * @returns true or false
+ */
+export function isValueContentLiteralHex(valueContent: string): boolean {
+  return isHexStrict(valueContent);
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -816,3 +816,13 @@ export const duplicateMultiTypeERC725SchemaEntry = (
 export function isValidUintSize(bitSize: number) {
   return bitSize >= 8 && bitSize <= 256 && bitSize % 8 === 0;
 }
+
+/*
+ * `bytesN` must be a valid number of bytes between 1 and 32
+ * e.g: bytes1, bytes2, bytes3, bytes4, ..., bytes32
+ *
+ * @param bytesSize the size of the fixed size bytes value
+ */
+export function isValidBytesSize(bytesSize: number) {
+  return bytesSize >= 1 && bytesSize <= 32;
+}

--- a/test/mockSchema.ts
+++ b/test/mockSchema.ts
@@ -357,8 +357,7 @@ export const mockSchema: (ERC725JSONSchema & {
     returnRawDataArray: abiCoder.encodeParameter('bytes[]', [
       '0x0000000000000000000000000000000000000000000000000000000000000063',
     ]),
-    returnGraphData:
-      '0x0000000000000000000000000000000000000000000000000000000000000063',
+    returnGraphData: '0x63',
     expectedResult: 99,
   },
 


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

⭐ Feature
🐛 Bug Fix

### What is the current behaviour (you can also link to an open issue here)?

**Bug**

When encoding `uintN` in tuples and the `valueContent` is `Number`, these are always encoded to a `uint256` as a 32 bytes long value because of the following line in the code:

https://github.com/ERC725Alliance/erc725.js/blob/06d872baa75fb3bfaac3e51c541e727eb76646e7/src/lib/encoder.ts#L675-L690

**Missing Feature**

Additionally, there is only support for few `bytesN` types, like `bytes2`, `bytes4`, `bytes8`, etc...

### What is the new behaviour (if this is a feature change)?

This the padding for the encoding of uintN and bytesN + add support for multiple `bytesN`


