### PR TITLE
feat: add `dynamicName` in schema returned by `getSchema`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,7 @@ export {
 export { getDataFromExternalSources } from './lib/getDataFromExternalSources';
 export { encodePermissions, decodePermissions } from './lib/permissions';
 export { checkPermissions } from './lib/detector';
+export { getSchema } from './lib/schemaParser';
 
 // PRIVATE FUNCTION
 function initializeProvider(providerOrRpcUrl, gasInfo) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import { encodeKeyName, isDynamicKeyName } from './lib/encodeKeyName';
 import { ERC725Config, ERC725Options } from './types/Config';
 import { Permissions } from './types/Method';
 import {
+  DynamicNameSchema,
   ERC725JSONSchema,
   ERC725JSONSchemaKeyType,
   ERC725JSONSchemaValueContent,
@@ -359,15 +360,19 @@ export class ERC725 {
   getSchema(
     keyOrKeys: string[],
     providedSchemas?: ERC725JSONSchema[],
-  ): Record<string, ERC725JSONSchema | null>;
+  ): Record<string, ERC725JSONSchema | DynamicNameSchema | null>;
   getSchema(
     keyOrKeys: string,
     providedSchemas?: ERC725JSONSchema[],
-  ): ERC725JSONSchema | null;
+  ): ERC725JSONSchema | DynamicNameSchema | null;
   getSchema(
     keyOrKeys: string | string[],
     providedSchemas?: ERC725JSONSchema[],
-  ): ERC725JSONSchema | null | Record<string, ERC725JSONSchema | null> {
+  ):
+    | ERC725JSONSchema
+    | DynamicNameSchema
+    | null
+    | Record<string, ERC725JSONSchema | DynamicNameSchema | null> {
     return getSchema(
       keyOrKeys,
       this.options.schemas.concat(providedSchemas || []),

--- a/src/lib/encodeKeyName.ts
+++ b/src/lib/encodeKeyName.ts
@@ -34,7 +34,7 @@ import { DynamicKeyParts } from '../types/dynamicKeys';
 const dynamicTypes = ['<string>', '<address>', '<bool>'];
 
 // https://docs.soliditylang.org/en/v0.8.14/abi-spec.html#types
-const dynamicTypesRegex = /<(uint|int|bytes)(\d+)>/;
+export const dynamicTypesRegex = /<(uint|int|bytes)(\d+)>/;
 
 /**
  *

--- a/src/lib/schemaParser.test.ts
+++ b/src/lib/schemaParser.test.ts
@@ -13,7 +13,7 @@
 */
 
 import assert from 'assert';
-import { DynamicNameSchema } from '../types/ERC725JSONSchema';
+import { ERC725JSONSchema } from '../types/ERC725JSONSchema';
 
 import { getSchema } from './schemaParser';
 
@@ -101,13 +101,11 @@ describe('schemaParser getSchema', () => {
         '0xeafec4d89fa9619884b60000f4d7faed14a1ab658d46d385bc29fb1eeaa56d0b',
       );
 
-      console.log('schema ', schema);
-
       assert.deepStrictEqual(schema, {
         name: 'SupportedStandards:??????',
         key: '0xeafec4d89fa9619884b60000f4d7faed14a1ab658d46d385bc29fb1eeaa56d0b',
         keyType: 'Mapping',
-        valueContent: '?',
+        valueContent: '0x5ef83ad9',
         valueType: 'bytes4',
       });
     });
@@ -118,11 +116,9 @@ describe('schemaParser getSchema', () => {
       const dynamicName = `MyCoolAddress:0x${address}`;
       const key = `0x22496f48a493035f00000000${address}`;
 
-      const extraSchema: DynamicNameSchema = {
+      const extraSchema: ERC725JSONSchema = {
         name,
-        dynamicName,
         key,
-        dynamicKeyPart: `0x${address}`,
         keyType: 'Mapping',
         valueContent: 'Address',
         valueType: 'address',
@@ -130,21 +126,24 @@ describe('schemaParser getSchema', () => {
 
       const schema = getSchema(key, [extraSchema]);
 
-      assert.deepStrictEqual(schema, extraSchema);
+      assert.deepStrictEqual(schema, {
+        ...extraSchema,
+        dynamicKeyPart: `0x${address}`,
+        dynamicName,
+      });
     });
 
     it('finds known SomeBytes32Mapping:<bytes32>', () => {
       const bytes32Value =
         '1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff';
       const name = 'SomeBytes32Mapping:<bytes32>';
-      const dynamicName = `SomeBytes32Mapping:0x${bytes32Value}`;
-      const key = `0x0cfc51aec37c55a4d0b10000${bytes32Value.slice(0, 42)}`;
+      const dynamicPart = bytes32Value.slice(0, 40);
+      const dynamicName = `SomeBytes32Mapping:0x${dynamicPart}`;
+      const key = `0x0cfc51aec37c55a4d0b10000${dynamicPart}`;
 
-      const extraSchema: DynamicNameSchema = {
+      const extraSchema: ERC725JSONSchema = {
         name,
-        dynamicName,
         key,
-        dynamicKeyPart: `0x${bytes32Value}`,
         keyType: 'Mapping',
         valueContent: 'Address',
         valueType: 'address',
@@ -152,7 +151,11 @@ describe('schemaParser getSchema', () => {
 
       const schema = getSchema(key, [extraSchema]);
 
-      assert.deepStrictEqual(schema, extraSchema);
+      assert.deepStrictEqual(schema, {
+        ...extraSchema,
+        dynamicName,
+        dynamicKeyPart: `0x${dynamicPart}`,
+      });
     });
 
     it('finds known SomeSelectorMap:<bytes4>', () => {
@@ -161,11 +164,9 @@ describe('schemaParser getSchema', () => {
       const dynamicName = `SomeSelectorMap:0x${bytes4Value}`;
       const key = `0x0cfc51aec37c55a4d0b10000${bytes4Value}00000000000000000000000000000000`;
 
-      const extraSchema: DynamicNameSchema = {
+      const extraSchema: ERC725JSONSchema = {
         name,
-        dynamicName,
         key,
-        dynamicKeyPart: `0x${bytes4Value}`,
         keyType: 'Mapping',
         valueContent: '(Address,bool)',
         valueType: '(address,bool)',
@@ -173,7 +174,36 @@ describe('schemaParser getSchema', () => {
 
       const schema = getSchema(key, [extraSchema]);
 
-      assert.deepStrictEqual(schema, extraSchema);
+      assert.deepStrictEqual(schema, {
+        ...extraSchema,
+        dynamicName,
+        dynamicKeyPart: `0x${bytes4Value}`,
+      });
+    });
+
+    it('finds Known LSP1UniversalReceiverDelegate:<bytes32> ', () => {
+      const bytes32value =
+        'cafecafecafecafecafecafecafecafecafecafef00df00df00df00df00df00d';
+      const name = 'LSP1UniversalReceiverDelegate:<bytes32>';
+      const dynamicPart = bytes32value.slice(0, 40);
+      const dynamicName = `LSP1UniversalReceiverDelegate:0x${dynamicPart}`;
+      const key = `0x0cfc51aec37c55a4d0b10000${dynamicPart}`;
+
+      const extraSchema: ERC725JSONSchema = {
+        name,
+        key,
+        keyType: 'Mapping',
+        valueContent: 'Address',
+        valueType: 'address',
+      };
+
+      const schema = getSchema(key, [extraSchema]);
+
+      assert.deepStrictEqual(schema, {
+        ...extraSchema,
+        dynamicName,
+        dynamicKeyPart: `0x${dynamicPart}`,
+      });
     });
   });
 

--- a/src/lib/schemaParser.test.ts
+++ b/src/lib/schemaParser.test.ts
@@ -101,6 +101,8 @@ describe('schemaParser getSchema', () => {
         '0xeafec4d89fa9619884b60000f4d7faed14a1ab658d46d385bc29fb1eeaa56d0b',
       );
 
+      console.log('schema ', schema);
+
       assert.deepStrictEqual(schema, {
         name: 'SupportedStandards:??????',
         key: '0xeafec4d89fa9619884b60000f4d7faed14a1ab658d46d385bc29fb1eeaa56d0b',
@@ -113,13 +115,14 @@ describe('schemaParser getSchema', () => {
     it('finds Known Mapping:<address> ', () => {
       const address = 'af3bf2ffb025098b79caddfbdd113b3681817744';
       const name = 'MyCoolAddress:<address>';
-      const dynamicName = `MyCoolAddress:${address}`;
+      const dynamicName = `MyCoolAddress:0x${address}`;
       const key = `0x22496f48a493035f00000000${address}`;
 
       const extraSchema: DynamicNameSchema = {
         name,
         dynamicName,
         key,
+        dynamicKeyPart: `0x${address}`,
         keyType: 'Mapping',
         valueContent: 'Address',
         valueType: 'address',
@@ -134,13 +137,14 @@ describe('schemaParser getSchema', () => {
       const bytes32Value =
         '1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff';
       const name = `SomeBytes32Mapping:<bytes32>`;
-      const dynamicName = `SomeBytes32Mapping:${bytes32Value}`;
+      const dynamicName = `SomeBytes32Mapping:0x${bytes32Value}`;
       const key = `0x0cfc51aec37c55a4d0b10000${bytes32Value.slice(0, 42)}`;
 
       const extraSchema: DynamicNameSchema = {
         name,
         dynamicName,
         key,
+        dynamicKeyPart: `0x${bytes32Value}`,
         keyType: 'Mapping',
         valueContent: 'Address',
         valueType: 'address',
@@ -154,13 +158,14 @@ describe('schemaParser getSchema', () => {
     it('finds known SomeSelectorMap:<bytes4>', () => {
       const bytes4Value = 'beefbeef';
       const name = `SomeSelectorMap:<bytes4>`;
-      const dynamicName = `SomeSelectorMap:${bytes4Value}`;
+      const dynamicName = `SomeSelectorMap:0x${bytes4Value}`;
       const key = `0x0cfc51aec37c55a4d0b10000${bytes4Value}00000000000000000000000000000000`;
 
       const extraSchema: DynamicNameSchema = {
         name,
         dynamicName,
         key,
+        dynamicKeyPart: `0x${bytes4Value}`,
         keyType: 'Mapping',
         valueContent: '(Address,bool)',
         valueType: '(address,bool)',
@@ -176,7 +181,7 @@ describe('schemaParser getSchema', () => {
     it('finds MappingWithGrouping', () => {
       const address = 'af3bf2ffb025098b79caddfbdd113b3681817744';
       const name = `AddressPermissions:Permissions:<address>`;
-      const dynamicName = `AddressPermissions:Permissions:${address}`;
+      const dynamicName = `AddressPermissions:Permissions:0x${address}`;
       const key = `0x4b80742de2bf82acb3630000${address}`;
       const schema = getSchema(key);
 
@@ -184,6 +189,7 @@ describe('schemaParser getSchema', () => {
         name,
         dynamicName,
         key,
+        dynamicKeyPart: `0x${address}`,
         keyType: 'MappingWithGrouping',
         valueContent: 'BitArray',
         valueType: 'bytes32',

--- a/src/lib/schemaParser.test.ts
+++ b/src/lib/schemaParser.test.ts
@@ -13,7 +13,7 @@
 */
 
 import assert from 'assert';
-import { ERC725JSONSchema } from '../types/ERC725JSONSchema';
+import { DynamicNameSchema } from '../types/ERC725JSONSchema';
 
 import { getSchema } from './schemaParser';
 
@@ -112,11 +112,13 @@ describe('schemaParser getSchema', () => {
 
     it('finds Known Mapping:<address> ', () => {
       const address = 'af3bf2ffb025098b79caddfbdd113b3681817744';
-      const name = `MyCoolAddress:${address}`;
+      const name = 'MyCoolAddress:<address>';
+      const dynamicName = `MyCoolAddress:${address}`;
       const key = `0x22496f48a493035f00000000${address}`;
 
-      const extraSchema: ERC725JSONSchema = {
+      const extraSchema: DynamicNameSchema = {
         name,
+        dynamicName,
         key,
         keyType: 'Mapping',
         valueContent: 'Address',
@@ -131,11 +133,13 @@ describe('schemaParser getSchema', () => {
     it('finds known SomeBytes32Mapping:<bytes32>', () => {
       const bytes32Value =
         '1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff';
-      const name = `SomeBytes32Mapping:${bytes32Value}`;
+      const name = `SomeBytes32Mapping:<bytes32>`;
+      const dynamicName = `SomeBytes32Mapping:${bytes32Value}`;
       const key = `0x0cfc51aec37c55a4d0b10000${bytes32Value.slice(0, 42)}`;
 
-      const extraSchema: ERC725JSONSchema = {
+      const extraSchema: DynamicNameSchema = {
         name,
+        dynamicName,
         key,
         keyType: 'Mapping',
         valueContent: 'Address',
@@ -149,11 +153,13 @@ describe('schemaParser getSchema', () => {
 
     it('finds known SomeSelectorMap:<bytes4>', () => {
       const bytes4Value = 'beefbeef';
-      const name = `SomeSelectorMap:${bytes4Value}`;
+      const name = `SomeSelectorMap:<bytes4>`;
+      const dynamicName = `SomeSelectorMap:${bytes4Value}`;
       const key = `0x0cfc51aec37c55a4d0b10000${bytes4Value}00000000000000000000000000000000`;
 
-      const extraSchema: ERC725JSONSchema = {
+      const extraSchema: DynamicNameSchema = {
         name,
+        dynamicName,
         key,
         keyType: 'Mapping',
         valueContent: '(Address,bool)',
@@ -169,12 +175,14 @@ describe('schemaParser getSchema', () => {
   describe('MappingWithGrouping', () => {
     it('finds MappingWithGrouping', () => {
       const address = 'af3bf2ffb025098b79caddfbdd113b3681817744';
-      const name = `AddressPermissions:Permissions:${address}`;
+      const name = `AddressPermissions:Permissions:<address>`;
+      const dynamicName = `AddressPermissions:Permissions:${address}`;
       const key = `0x4b80742de2bf82acb3630000${address}`;
       const schema = getSchema(key);
 
       assert.deepStrictEqual(schema, {
         name,
+        dynamicName,
         key,
         keyType: 'MappingWithGrouping',
         valueContent: 'BitArray',

--- a/src/lib/schemaParser.test.ts
+++ b/src/lib/schemaParser.test.ts
@@ -136,7 +136,7 @@ describe('schemaParser getSchema', () => {
     it('finds known SomeBytes32Mapping:<bytes32>', () => {
       const bytes32Value =
         '1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff';
-      const name = `SomeBytes32Mapping:<bytes32>`;
+      const name = 'SomeBytes32Mapping:<bytes32>';
       const dynamicName = `SomeBytes32Mapping:0x${bytes32Value}`;
       const key = `0x0cfc51aec37c55a4d0b10000${bytes32Value.slice(0, 42)}`;
 
@@ -157,7 +157,7 @@ describe('schemaParser getSchema', () => {
 
     it('finds known SomeSelectorMap:<bytes4>', () => {
       const bytes4Value = 'beefbeef';
-      const name = `SomeSelectorMap:<bytes4>`;
+      const name = 'SomeSelectorMap:<bytes4>';
       const dynamicName = `SomeSelectorMap:0x${bytes4Value}`;
       const key = `0x0cfc51aec37c55a4d0b10000${bytes4Value}00000000000000000000000000000000`;
 
@@ -180,7 +180,7 @@ describe('schemaParser getSchema', () => {
   describe('MappingWithGrouping', () => {
     it('finds MappingWithGrouping', () => {
       const address = 'af3bf2ffb025098b79caddfbdd113b3681817744';
-      const name = `AddressPermissions:Permissions:<address>`;
+      const name = 'AddressPermissions:Permissions:<address>';
       const dynamicName = `AddressPermissions:Permissions:0x${address}`;
       const key = `0x4b80742de2bf82acb3630000${address}`;
       const schema = getSchema(key);

--- a/src/lib/schemaParser.ts
+++ b/src/lib/schemaParser.ts
@@ -121,16 +121,18 @@ const findMappingSchemaForKey = (
     key,
   };
 
+  // 3. mappings with dynamic key part
   // replace dynamic placeholder in the map part (e.g: <address>, <bytes32>) with the hex value
   if (isDynamicKeyName(keySchema.name)) {
     dynamicPartName = secondWordHex;
-    result['dynamicName'] = `${keyNameParts[0]}:${dynamicPartName}`;
+    result['dynamicName'] = `${keyNameParts[0]}:0x${dynamicPartName}`;
+    result['dynamicKeyPart'] = `0x${secondWordHex}`;
   }
 
   // if first 20 bytes of the hash of second word in schema match,
   // display the map part as plain word
   if (keccak256(keyNameParts[1]).substring(0, 26) === secondWordHex) {
-    [, dynamicPartName] = keyNameParts;
+    [, dynamicPartName] = `0x${keyNameParts}`;
   }
 
   return result;
@@ -145,16 +147,21 @@ const findMappingWithGroupingSchemaForKey = (
       (schema) => schema.key.substring(0, 26) === key.substring(0, 26),
     ) || null;
 
-  const address = key.substring(26);
-
   if (keySchema) {
+    const keyNameParts = keySchema.name.split(':');
+
+    const dynamicKeyPart = key.substring(26);
+
+    if (isDynamicKeyName(keySchema.name)) {
+      keySchema[
+        'dynamicName'
+      ] = `${keyNameParts[0]}:${keyNameParts[1]}:0x${dynamicKeyPart}`;
+      keySchema['dynamicKeyPart'] = `0x${dynamicKeyPart}`;
+    }
+
     return {
       ...keySchema,
       key,
-      dynamicName: `${keySchema.name.substring(
-        0,
-        keySchema.name.lastIndexOf(':'),
-      )}:${address}`,
     };
   }
 

--- a/src/lib/schemaParser.ts
+++ b/src/lib/schemaParser.ts
@@ -171,7 +171,7 @@ const findMappingWithGroupingSchemaForKey = (
 function schemaParser(
   key: string,
   schemas: ERC725JSONSchema[],
-): ERC725JSONSchema | null {
+): ERC725JSONSchema | DynamicNameSchema | null {
   const schemasByKeyType = getSchemasByKeyType(schemas);
 
   let foundSchema: ERC725JSONSchema | null = null;
@@ -205,20 +205,23 @@ function schemaParser(
 export function getSchema(
   keyOrKeys: string | string[],
   providedSchemas?: ERC725JSONSchema[],
-): ERC725JSONSchema | null | Record<string, ERC725JSONSchema | null> {
+):
+  | ERC725JSONSchema
+  | DynamicNameSchema
+  | null
+  | Record<string, ERC725JSONSchema | DynamicNameSchema | null> {
   let fullSchema: ERC725JSONSchema[] = allSchemas;
   if (providedSchemas) {
     fullSchema = fullSchema.concat(providedSchemas);
   }
 
   if (Array.isArray(keyOrKeys)) {
-    return keyOrKeys.reduce<Record<string, ERC725JSONSchema | null>>(
-      (acc, key) => {
-        acc[key] = schemaParser(key, fullSchema);
-        return acc;
-      },
-      {},
-    );
+    return keyOrKeys.reduce<
+      Record<string, ERC725JSONSchema | DynamicNameSchema | null>
+    >((acc, key) => {
+      acc[key] = schemaParser(key, fullSchema);
+      return acc;
+    }, {});
   }
 
   return schemaParser(keyOrKeys, fullSchema);

--- a/src/lib/schemaParser.ts
+++ b/src/lib/schemaParser.ts
@@ -125,8 +125,9 @@ const findMappingSchemaForKey = (
   // replace dynamic placeholder in the map part (e.g: <address>, <bytes32>) with the hex value
   if (isDynamicKeyName(keySchema.name)) {
     dynamicPartName = secondWordHex;
-    result['dynamicName'] = `${keyNameParts[0]}:0x${dynamicPartName}`;
-    result['dynamicKeyPart'] = `0x${secondWordHex}`;
+    (result as DynamicNameSchema).dynamicName =
+      `${keyNameParts[0]}:0x${dynamicPartName}`;
+    (result as DynamicNameSchema).dynamicKeyPart = `0x${secondWordHex}`;
   }
 
   // if first 20 bytes of the hash of second word in schema match,
@@ -153,10 +154,9 @@ const findMappingWithGroupingSchemaForKey = (
     const dynamicKeyPart = key.substring(26);
 
     if (isDynamicKeyName(keySchema.name)) {
-      keySchema[
-        'dynamicName'
-      ] = `${keyNameParts[0]}:${keyNameParts[1]}:0x${dynamicKeyPart}`;
-      keySchema['dynamicKeyPart'] = `0x${dynamicKeyPart}`;
+      (keySchema as DynamicNameSchema).dynamicName =
+        `${keyNameParts[0]}:${keyNameParts[1]}:0x${dynamicKeyPart}`;
+      (keySchema as DynamicNameSchema).dynamicKeyPart = `0x${dynamicKeyPart}`;
     }
 
     return {

--- a/src/types/ERC725JSONSchema.ts
+++ b/src/types/ERC725JSONSchema.ts
@@ -163,3 +163,9 @@ export interface ERC725JSONSchema {
   valueContent: ERC725JSONSchemaValueContent | string; // string holds '0x1345ABCD...' If the value content are specific bytes, than the returned value is expected to equal those bytes.
   valueType: ERC725JSONSchemaValueType | string; // The type of the value. This is used to determine how the value should be encoded / decode (`string` for tuples and CompactBytesArray).
 }
+
+// The dynamic part placeholder in the `name` of ERC725JSONSchema is preserved to allow re-encoding after the schema
+// of a hex data key got retrieved via `getSchema(...)`.
+export interface DynamicNameSchema extends ERC725JSONSchema {
+  dynamicName: string; // Describes the name of the key where the dynamic part (<address>, <bytes32) is replaced by the actual mapped value.
+}

--- a/src/types/ERC725JSONSchema.ts
+++ b/src/types/ERC725JSONSchema.ts
@@ -168,4 +168,5 @@ export interface ERC725JSONSchema {
 // of a hex data key got retrieved via `getSchema(...)`.
 export interface DynamicNameSchema extends ERC725JSONSchema {
   dynamicName: string; // Describes the name of the key where the dynamic part (<address>, <bytes32) is replaced by the actual mapped value.
+  dynamicKeyPart: string;
 }


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

:star: Feature

### What is the current behaviour (you can also link to an open issue here)?

#400 introduced a change in the `getSchema` function that replaces the dynamic part `<...>` with the actual hex value in the `name` of the schema.

However, this causes a problem has the schem returned cannot be used anymore as it will the `name` now contains a hex value and `ERC725.encodeData` or `ERC725.decodeData` will not find the name anymore when searching through the data keys.

### What is the new behaviour (if this is a feature change)?

- [x] Add an extra property `dynamicName` returned in the schema when dealing with `Mapping` and `MappingWithGrouping` data keys when using `getSchema(...)`
- [x] Preserves the full `name` of the data key to address the issue mentioned above.
- [x] Export `getSchema` function standalone, to make it available outside of class instance

### Other information:

None