### PR TITLE
feat: allow to decode array length only as number using `decodeData`

### DIFF
--- a/src/lib/decodeData.test.ts
+++ b/src/lib/decodeData.test.ts
@@ -263,6 +263,27 @@ describe('decodeData', () => {
     ]);
   });
 
+  it('parses type Array correctly but just the array length', () => {
+    const decodedData = decodeData(
+      {
+        keyName: 'LSP12IssuedAssets[]',
+        value: '0x00000000000000000000000000000003',
+      },
+      [
+        {
+          name: 'LSP12IssuedAssets[]',
+          key: '0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd',
+          keyType: 'Array',
+          valueContent: 'Address',
+          valueType: 'address',
+        },
+      ],
+    );
+
+    expect(decodedData.name).to.eql('LSP12IssuedAssets[]');
+    expect(decodedData.value).to.eql(3);
+  });
+
   it('decodes dynamic keys', () => {
     const decodedData = decodeData(
       [


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

⭐ Feature

### What is the current behaviour (you can also link to an open issue here)?

When using `decodeData` with key type Array, only arrays `[ ... ]` can be returned.

### What is the new behaviour (if this is a feature change)?

Allow to use `decodeData` with key type Array that allows to pass a a 16 bytes long value, that will be decoded as a number.

```js
const decodedData = ERC725.decodeData(
      {
        keyName: 'LSP12IssuedAssets[]',
        value: '0x00000000000000000000000000000003',
      },
      [
        {
          name: 'LSP12IssuedAssets[]',
          key: '0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd',
          keyType: 'Array',
          valueContent: 'Address',
          valueType: 'address',
        },
      ],
    );
```

will output:

```
// decodedData {
//  key: '0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd',
//  name: 'LSP12IssuedAssets[]',
//  value: 3
// }
```

### Other information:
