### PR TITLE
feat: allow to pass `number` directly in array when encoding tuples

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -937,6 +937,34 @@ describe('Running @erc725/erc725.js tests...', () => {
         });
       });
     });
+
+    describe('for tuples', () => {
+      it('encode `(bytes4,uint128)`', () => {
+        const schema = {
+          name: 'LSP4CreatorsMap:<address>',
+          key: '0x6de85eaf5d982b4e5da00000<address>',
+          keyType: 'Mapping',
+          valueType: '(bytes4,uint128)',
+          valueContent: '(Bytes4,Number)',
+        };
+
+        const expectedEncodedValue =
+          '0xb3c4928f00000000000000000000000000000005';
+
+        const result = ERC725.encodeData(
+          [
+            {
+              keyName: 'LSP4CreatorsMap:<address>',
+              dynamicKeyParts: address,
+              value: ['0xb3c4928f', 5],
+            },
+          ],
+          [schema],
+        );
+
+        assert.equal(result.values[0], expectedEncodedValue);
+      });
+    });
   });
 
   describe('Testing utility encoding & decoding functions', () => {

--- a/src/types/encodeData/JSONURL.ts
+++ b/src/types/encodeData/JSONURL.ts
@@ -32,7 +32,8 @@ export type EncodeDataType =
   | string[]
   | URLDataToEncode
   | boolean
-  | number;
+  | number
+  | (string | number)[]; // for tuples such as `(bytes4,uint128)`
 
 export interface EncodeDataReturn {
   keys: string[];


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

🌟 Feature

### What is the current behaviour (you can also link to an open issue here)?

Current when encoding parts in tuples that are `uintN`, it is not possible to pass a plain `number`. The number always needs to be encoded as hex first, as tuples only accept `string` type.

![image](https://github.com/ERC725Alliance/erc725.js/assets/31145285/0092fa85-a476-415b-9f9e-87b448c7f90c)


### What is the new behaviour (if this is a feature change)?

Fix this behaviour by allowing to pass `number` for encoding.

### Other information:

Closes #393 
