### PR TITLE
docs: add missing code sandbox from docs.lukso.tech

### DIFF
--- a/docs/methods.md
+++ b/docs/methods.md
@@ -3,6 +3,10 @@ sidebar_position: 1
 title: 'Methods'
 ---
 
+import CodeSandbox from "../../../src/components/CodeSandbox";
+
+<CodeSandbox />
+
 ## Encoding
 
 ### encodeData


### PR DESCRIPTION
See PRs from docs.lukso.tech for reference: https://github.com/lukso-network/docs/pull/993/files

<img width="1658" alt="image" src="https://github.com/ERC725Alliance/erc725.js/assets/31145285/24478fa4-a590-4f80-824b-ad1dc7d96d8a">
