### PR TITLE
Revert "refactor: improve code for `Literal` hex for `valueContent`" to return `null` when decoding

### DIFF
--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -948,8 +948,10 @@ export function encodeValueContent(
   valueContent: string,
   value: string | number | AssetURLEncode | URLDataToEncode | boolean,
 ): string | false {
-  if (valueContent.slice(0, 2) === '0x') {
-    return valueContent === value ? value : false;
+  if (isValueContentLiteralHex(valueContent)) {
+    // hex characters are always lower case, even if the schema define some hex words uppercase
+    // e.g: 0xAabbcCddeE -> encoded as 0xaabbccddee
+    return valueContent === value ? value.toLowerCase() : false;
   }
 
   const valueContentEncodingMethods = valueContentEncodingMap(valueContent);
@@ -983,12 +985,7 @@ export function decodeValueContent(
   value: string,
 ): string | URLDataWithHash | number | boolean | null {
   if (isValueContentLiteralHex(valueContent)) {
-    if (valueContent.toLowerCase() !== value) {
-      throw new Error(
-        `Could not decode value content: the value ${value} does not match the Hex Literal ${valueContent} defined in the \`valueContent\` part of the schema`,
-      );
-    }
-    return valueContent;
+    return valueContent.toLowerCase() === value ? valueContent : null;
   }
 
   if (value == null || value === '0x') {

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -21,7 +21,6 @@ import { keccak256, utf8ToHex } from 'web3-utils';
 import {
   ERC725JSONSchema,
   ERC725JSONSchemaKeyType,
-  ERC725JSONSchemaValueType,
 } from '../types/ERC725JSONSchema';
 import { GetDataDynamicKey } from '../types/GetData';
 
@@ -226,12 +225,12 @@ describe('utils', () => {
     testCases.forEach((testCase) => {
       it(`encodes/decodes keyType Array / tuples (valueContent: ${testCase.schema.valueContent}, valueType: ${testCase.schema.valueType}`, () => {
         assert.deepStrictEqual(
-          encodeKey(testCase.schema as ERC725JSONSchema, testCase.decodedValue),
+          encodeKey(testCase.schema, testCase.decodedValue),
           testCase.encodedValue,
         );
 
         assert.deepStrictEqual(
-          decodeKey(testCase.schema as ERC725JSONSchema, testCase.encodedValue),
+          decodeKey(testCase.schema, testCase.encodedValue),
           testCase.decodedValue,
         );
       });
@@ -378,7 +377,7 @@ describe('utils', () => {
         valueContent: '0xc9aaAE3201F40fd0fF04D9c885769d8256A456ab',
         valueType: 'bytes',
         decodedValue: '0xc9aaAE3201F40fd0fF04D9c885769d8256A456ab',
-        encodedValue: '0xc9aaae3201f40fd0ff04d9c885769d8256a456ab', // encoded hex is always lower case
+        encodedValue: '0xc9aaae3201f40fd0ff04d9c885769d8256a456ab',
       },
     ];
 
@@ -387,7 +386,7 @@ describe('utils', () => {
         assert.strictEqual(
           encodeKeyValue(
             testCase.valueContent,
-            testCase.valueType as ERC725JSONSchemaValueType,
+            testCase.valueType,
             testCase.decodedValue,
           ),
           testCase.encodedValue,
@@ -397,7 +396,7 @@ describe('utils', () => {
         assert.deepStrictEqual(
           decodeKeyValue(
             testCase.valueContent,
-            testCase.valueType as ERC725JSONSchemaValueType,
+            testCase.valueType,
             testCase.encodedValue,
           ),
           testCase.decodedValue,


### PR DESCRIPTION
This reverts commit 3e6213a3acf3b5d16b79447f87a7029f1020d7b3.

### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

### What is the current behaviour (you can also link to an open issue here)?

### What is the new behaviour (if this is a feature change)?

### Other information:
