### PR TITLE
improvement: fetchData return null if no key not found

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 20.x
+nodejs 20.0.0

--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,7 @@
     "formatter": {
       "semicolons": "always",
       "quoteStyle": "single",
-      "trailingComma": "all"
+      "trailingCommas": "all"
     }
   },
   "organizeImports": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@erc725/erc725.js",
-  "version": "0.24.0",
+  "version": "0.27.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@erc725/erc725.js",
-      "version": "0.24.0",
+      "version": "0.27.1",
       "license": "Apache-2.0",
       "dependencies": {
         "cross-fetch": "^4.0.0",


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
improvement to fetchData method
### What is the current behaviour (you can also link to an open issue here)?
right now fetchData throws an exception if we try to fetchData of a non existing key. We think it should return just null in this case
### What is the new behaviour (if this is a feature change)?
if fetchData receives an non existing key on contract it should just return null
### Other information:
