### PR TITLE
Fix: Bug when encoding/decoding bool values

### DIFF
--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -515,8 +515,11 @@ const valueTypeEncodingMap = (
     case 'bool':
     case 'boolean':
       return {
-        encode: (value: boolean) => (value ? '0x01' : '0x00'),
-        decode: (value: string) => value === '0x01',
+        encode: (value: boolean) => (value
+                                     ? '0x0000000000000000000000000000000000000000000000000000000000000001'
+                                     : '0x0000000000000000000000000000000000000000000000000000000000000000'
+                                    ),
+        decode: (value: string) => value === '0x0000000000000000000000000000000000000000000000000000000000000001',
       };
     case 'string':
       return {


### PR DESCRIPTION
Correct ABI-encoded bool is:
`0x0000000000000000000000000000000000000000000000000000000000000001` for true or
`0x0000000000000000000000000000000000000000000000000000000000000000` for false (32 bytes)

But currently returning `0x01` or `0x00` instead which is a bug.

### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?
Bug fix for incorrect "bool" encoding

### What is the current behaviour (you can also link to an open issue here)?
In Solidity `abi.decode(erc725BoolEncodedValue, (bool)) `will fail because expecting 32 bytes. Currently being encoded as `0x01` or `0x00`

### What is the new behaviour (if this is a feature change)?
Correctly encoded as `0x0000000000000000000000000000000000000000000000000000000000000001` for true or
`0x0000000000000000000000000000000000000000000000000000000000000000` for false
