### PR TITLE
docs: update URL for ERC725 Inspect Tool to reflect correct network

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ This package is currently in the early stages of development. Feel free to [repo
 The `@erc725/erc725.js` package allows you to retrieve, encode and decode data easily from any ERC725Y smart contracts using ERC725Y JSON Schemas.
 
 :::tip ERC725 Inspect
-You can easily retrieve the list of metadata and permissions from Universal Profile and Digital Assets, as well as encoding and decoding data using the [ERC725 Inspect Tool](https://erc725-inspect.lukso.tech/?network=mainnet).
+You can easily retrieve the list of metadata and permissions from Universal Profile and Digital Assets, as well as encoding and decoding data using the [ERC725 Inspect Tool](https://erc725-inspect.lukso.tech/?network=lukso+mainnet).
 :::
 
 ## Installation


### PR DESCRIPTION
### What kind of change does this PR introduce (bug fix, feature, docs update, ...)?

URL update for the erc725-inspect

### What is the current behaviour (you can also link to an open issue here)?

### What is the new behaviour (if this is a feature change)?

### Other information:
